### PR TITLE
feat(products): unify search endpoints into single POST /api/product/…

### DIFF
--- a/client/src/context/ShopContext.jsx
+++ b/client/src/context/ShopContext.jsx
@@ -255,42 +255,41 @@ const ShopContextProvider = ({ children }) => {
         }
     }
 
-    // Búsqueda Lineal usando el endpoint del backend
-    const searchByTitleOrAuthor = async (searchTerm, searchBy = 'title') => {
+    // Búsqueda unificada de productos (detecta ISBN vs texto automáticamente)
+    const searchProducts = async (query, searchBy, limit = 20) => {
         try {
-            const { data } = await axios.post('/api/product/search/linear', {
-                searchTerm,
-                searchBy
-            });
+            const body = { query, limit };
+            if (searchBy) body.searchBy = searchBy;
 
-            if (data.success) {
-                return data.results;
-            }
-            return [];
-        } catch (error) {
-            console.error('Linear search error:', error);
-            return [];
-        }
-    }
-
-    // Búsqueda Binaria usando el endpoint del backend
-    const searchByISBN = async (isbn) => {
-        try {
-            const { data } = await axios.post('/api/product/search/binary', {
-                isbn
-            });
+            const { data } = await axios.post('/api/product/search', body);
 
             if (data.success) {
                 return {
-                    found: data.found,
-                    product: data.product
+                    products: data.products,
+                    searchType: data.searchType,
+                    count: data.count
                 };
             }
-            return { found: false, product: null };
+            return { products: [], searchType: 'text', count: 0 };
         } catch (error) {
-            console.error('Binary search error:', error);
-            return { found: false, product: null };
+            console.error('Search error:', error);
+            return { products: [], searchType: 'text', count: 0 };
         }
+    }
+
+    // Wrapper para compatibilidad hacia atrás (deprecado - usar searchProducts)
+    const searchByTitleOrAuthor = async (searchTerm, searchBy = 'title') => {
+        const result = await searchProducts(searchTerm, searchBy);
+        return result.products;
+    }
+
+    // Wrapper para compatibilidad hacia atrás (deprecado - usar searchProducts)
+    const searchByISBN = async (isbn) => {
+        const result = await searchProducts(isbn);
+        if (result.products.length > 0) {
+            return { found: true, product: result.products[0] };
+        }
+        return { found: false, product: null };
     }
 
     // Ordena productos por precio usando Merge Sort del backend
@@ -1025,7 +1024,7 @@ const ShopContextProvider = ({ children }) => {
     }, [])
 
     const value = {
-        books, navigate, user, setUser, currency, searchQuery, setSearchQuery, cartItems, setCartItems, addToCart, getCartCount, getCartAmount, updateQuantity, method, setMethod, delivery_charges, showUserLogin, setShowUserLogin, isAdmin, setIsAdmin, axios, fetchBooks, fetchUser, fetchAdmin, logoutUser, availableCategories, searchByTitleOrAuthor, searchByISBN, sortProductsByPrice, applyFiltersAndSort, profileData, setProfileData, profileImage, setProfileImage, imagePreview, setImagePreview, profileLoading, setProfileLoading, countryCodes, selectedCountryCode, setSelectedCountryCode, phoneNumber, setPhoneNumber, getUserProfile, loadProfileData, handleProfileImageChange, handlePhoneChange, updateProfileField, submitProfileUpdate, cancelProfileUpdate, resetProfileForm, shelves, fetchShelves, createShelf, assignBookToShelf, removeBookFromShelf, findDangerousCombinations, optimizeShelf, getUserLoans, getUserLoanStats, createLoan, returnBook, getAllLoans, getUserReservationStats, getUserReservationList, getWaitingList, createReservation, cancelReservation, reportLoading, downloadInventoryPDF, downloadInventoryXLSX, downloadLoansPDF, downloadLoansXLSX, getRecursionPreview, currentLanguage
+        books, navigate, user, setUser, currency, searchQuery, setSearchQuery, cartItems, setCartItems, addToCart, getCartCount, getCartAmount, updateQuantity, method, setMethod, delivery_charges, showUserLogin, setShowUserLogin, isAdmin, setIsAdmin, axios, fetchBooks, fetchUser, fetchAdmin, logoutUser, availableCategories, searchProducts, searchByTitleOrAuthor, searchByISBN, sortProductsByPrice, applyFiltersAndSort, profileData, setProfileData, profileImage, setProfileImage, imagePreview, setImagePreview, profileLoading, setProfileLoading, countryCodes, selectedCountryCode, setSelectedCountryCode, phoneNumber, setPhoneNumber, getUserProfile, loadProfileData, handleProfileImageChange, handlePhoneChange, updateProfileField, submitProfileUpdate, cancelProfileUpdate, resetProfileForm, shelves, fetchShelves, createShelf, assignBookToShelf, removeBookFromShelf, findDangerousCombinations, optimizeShelf, getUserLoans, getUserLoanStats, createLoan, returnBook, getAllLoans, getUserReservationStats, getUserReservationList, getWaitingList, createReservation, cancelReservation, reportLoading, downloadInventoryPDF, downloadInventoryXLSX, downloadLoansPDF, downloadLoansXLSX, getRecursionPreview, currentLanguage
     }
 
     return (

--- a/server/src/products/dto/linear-search.dto.ts
+++ b/server/src/products/dto/linear-search.dto.ts
@@ -8,7 +8,7 @@ export class LinearSearchDto {
     })
     @IsNotEmpty()
     @IsString()
-    searchTerm: string;
+    searchTerm!: string;
 
     @ApiProperty({
         example: 'title',

--- a/server/src/products/dto/search-product-response.dto.ts
+++ b/server/src/products/dto/search-product-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SearchProductResponseDto {
+    @ApiProperty({ example: true })
+    success!: boolean;
+
+    @ApiProperty({ example: 'Harry Potter', description: 'Original term of search' })
+    query!: string;
+
+    @ApiProperty({ example: 'text', enum: ['isbn', 'text'], description: 'Detected type of search' })
+    searchType!: 'isbn' | 'text';
+
+    @ApiProperty({ example: 3, description: 'Quantity of results found' })
+    count!: number;
+
+    @ApiProperty({
+        type: 'array',
+        description: 'Found products (empty array if no results found)',
+    })
+    products!: any[];
+}

--- a/server/src/products/dto/search-product.dto.ts
+++ b/server/src/products/dto/search-product.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class SearchProductDto {
+    @ApiProperty({
+        description: 'Search term (ISBN, author or text)',
+        example: 'Harry Potter'
+    })
+    @IsString()
+    query!: string;
+
+    @ApiProperty({
+        description: 'Results limit (only for text searches)',
+        required: false,
+        default: 20,
+        example: 20
+    })
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Max(100)
+    limit?: number;
+}

--- a/server/src/products/dto/search-product.dto.ts
+++ b/server/src/products/dto/search-product.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsInt, IsOptional, IsString, IsNotEmpty, Max, Min } from 'class-validator';
 
 export class SearchProductDto {
     @ApiProperty({
         description: 'Search term (ISBN, author or text)',
         example: 'Harry Potter'
     })
+    @IsNotEmpty()
     @IsString()
     query!: string;
 

--- a/server/src/products/product.controller.ts
+++ b/server/src/products/product.controller.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Body, Controller, Get, HttpStatus, Param, Post, Query, Res, UploadedFiles, UseGuards, UseInterceptors } from '@nestjs/common';
-import { ApiBody, ApiConsumes, ApiCookieAuth, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiCookieAuth, ApiExcludeEndpoint, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ProductService } from './product.service';
 import { AdminAuthGuard } from 'src/common/guards/admin-auth/admin-auth.guard';
 import { FilesInterceptor } from '@nestjs/platform-express';
@@ -8,6 +8,7 @@ import type { Response } from 'express';
 import { AddProductDto } from './dto/add-product.dto';
 import { SingleProductDto } from './dto/single-product.dto';
 import { ChangeStockDto } from './dto/change-stock.dto';
+import { SearchProductDto } from './dto/search-product.dto';
 
 @ApiTags('Product')
 @Controller('product')
@@ -159,9 +160,10 @@ export class ProductController {
     }
 
     /**
-     * Búsqueda Lineal por título o autor
+     * @deprecated Usar POST /api/product/search en su lugar
      */
     @Post('search/linear')
+    @ApiExcludeEndpoint(true)
     @ApiOperation({
         summary: 'Linear search by title or author',
         description: 'Searches in the unsorted general inventory using linear search algorithm (O(n))'
@@ -230,9 +232,10 @@ export class ProductController {
     }
 
     /**
-     * Búsqueda Binaria por ISBN (CRÍTICO)
+     * @deprecated Usar POST /api/product/search en su lugar
      */
     @Post('search/binary')
+    @ApiExcludeEndpoint()
     @ApiOperation({
         summary: 'Search by ISBN',
         description: 'Finds a product by ISBN using the unique sparse index in MongoDB (O(log n) in the DB). Used to verify pending reservations when returning books.'
@@ -276,6 +279,60 @@ export class ProductController {
                 isbn,
                 found: result.found,
                 product: result.product,
+            });
+        } catch (error: any) {
+            return res
+                .status(error.status || HttpStatus.INTERNAL_SERVER_ERROR)
+                .json({
+                    success: false,
+                    message: error.message,
+                });
+        }
+    }
+
+    /**
+     * Búsqueda unificada de productos
+     * Detecta automáticamente si el query es ISBN o texto.
+     */
+    @Post('search')
+    @ApiOperation({
+        summary: 'Search products by ISBN, title or author',
+        description: 'Unified search endpoint. Automatically detects ISBN format and delegates to the appropriate search strategy.'
+    })
+    @ApiBody({ type: SearchProductDto })
+    @ApiResponse({
+        status: 200,
+        description: 'Search completed successfully',
+        schema: {
+            type: 'object',
+            properties: {
+                success: { type: 'boolean', example: true },
+                query: { type: 'string', example: 'Harry Potter' },
+                searchType: { type: 'string', enum: ['isbn', 'text'], example: 'text' },
+                count: { type: 'number', example: 3 },
+                products: { type: 'array', items: { type: 'object' } }
+            }
+        }
+    })
+    async searchProducts(
+        @Body() dto: SearchProductDto,
+        @Res() res: Response
+    ) {
+        try {
+            const { query, limit } = dto;
+            const cleanQuery = query.replace(/-/g, '');
+            const searchType: 'isbn' | 'text' = /^\d{9}[\dX]$/.test(cleanQuery) || /^\d{13}$/.test(cleanQuery)
+                ? 'isbn'
+                : 'text';
+
+            const results = await this.productService.search(query, limit);
+
+            return res.status(HttpStatus.OK).json({
+                success: true,
+                query,
+                searchType,
+                count: results.length,
+                products: results,
             });
         } catch (error: any) {
             return res

--- a/server/src/products/product.service.ts
+++ b/server/src/products/product.service.ts
@@ -157,6 +157,34 @@ export class ProductService {
     }
 
     /**
+     * Búsqueda unified: detecta ISBN vs texto y delega al método apropiado.
+     * El cliente no necesita saber qué algoritmo se usa internamente.
+     */
+    async search(query: string, limit: number = 20): Promise<Product[]> {
+        const cleanQuery = query.replace(/-/g, '');
+        const isIsbn = /^\d{9}[\dX]$/.test(cleanQuery) || /^\d{13}$/.test(cleanQuery);
+
+        if (isIsbn) {
+            const result = await this.searchByISBN(cleanQuery);
+            return result.product ? [result.product] : [];
+        }
+
+        // Búsqueda de texto: busca en nombre Y autor simultáneamente
+        const results = await this.productModel
+            .find({
+                $or: [
+                    { name: { $regex: query, $options: 'i' } },
+                    { author: { $regex: query, $options: 'i' } }
+                ]
+            })
+            .limit(limit)
+            .lean()
+            .exec();
+
+        return results;
+    }
+
+    /**
      * Cambia el estado de stock de un producto
      * @returns Booleano. True si está en stock, false si no
      */


### PR DESCRIPTION
…search

Consolidate linear (title/author) and binary (ISBN) search into one endpoint that auto-detects the search type from the query format. This hides internal implementation details from the API contract.

- Add SearchProductDto with query, searchBy, and limit fields
- Add unified search() method in ProductService (searches name + author)
- Mark /search/linear and /search/binary as deprecated (hidden in Swagger)
- Add SearchProductResponseDto with searchType indicator
- Refactor ShopContext: new searchProducts() function + backward-compatible wrappers

Fixes: #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a single product search experience that handles both ISBN and text searches.
  * Search results now include the number of matches and the search type used.
  * Product search requests can optionally limit the number of returned results.

* **Bug Fixes**
  * Improved ISBN handling by accepting hyphenated input and matching more consistently.
  * Existing search options continue to work with the new search flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->