### PR TITLE
feat(security): add rate limiting to authentication endpoints

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -21,3 +21,5 @@ RESERVATION_SCORE_BETA=0.3     # Peso de puntualidad histórica
 RESERVATION_SCORE_GAMMA=0.2    # Peso de tiempo de espera
 RESERVATION_SCORE_DELTA=0.1    # Penalización por devoluciones tardías
 LOAN_FEE_ESTIMATE=5.00  # Fee estimado por préstamo para optimización del carrito
+THROTTLE_TTL=60000        # Ventana de tiempo en milisegundos (default: 60000 = 1 min)
+THROTTLE_LIMIT=100        # Maximo de requests por ventana por IP (default: 100)

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "@nestjs/mongoose": "^11.0.4",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.5",
+    "@nestjs/throttler": "^6.5.0",
     "bcryptjs": "^3.0.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@nestjs/swagger':
         specifier: ^11.2.5
         version: 11.4.3(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
+      '@nestjs/throttler':
+        specifier: ^6.5.0
+        version: 6.5.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(reflect-metadata@0.2.2)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -828,6 +831,13 @@ packages:
         optional: true
       '@nestjs/platform-express':
         optional: true
+
+  '@nestjs/throttler@6.5.0':
+    resolution: {integrity: sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -4469,6 +4479,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nestjs/platform-express': 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)
+
+  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
 
   '@noble/hashes@1.8.0': {}
 

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -6,6 +6,7 @@ import { AdminLoginDto } from './dto/admin-login.dto';
 import type { Response } from 'express';
 import { AdminAuthGuard } from 'src/common/guards/admin-auth/admin-auth.guard';
 import { AdminEmail } from 'src/common/decorators/admin/admin-email.decorator';
+import { Throttle } from '@nestjs/throttler';
 
 @ApiTags('Admin')
 @Controller('admin')
@@ -29,6 +30,7 @@ export class AdminController {
     }
 
     @Post('login')
+    @Throttle({ default: { limit: 5, ttl: 60000 } })
     @ApiOperation({ summary: 'Admin login' })
     @ApiBody({ type: AdminLoginDto })
     @ApiResponse({
@@ -50,7 +52,7 @@ export class AdminController {
                 success: true,
                 message,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(error.status || HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,
@@ -74,7 +76,7 @@ export class AdminController {
                 success: true,
                 message: result.message,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,
@@ -102,7 +104,7 @@ export class AdminController {
                 success: true,
                 email: result.email,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(error.status || HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -36,10 +36,14 @@ import { APP_GUARD } from '@nestjs/core';
     }),
 
     // Rate limiting global: 100 requests por 60 segundos por IP
-    ThrottlerModule.forRoot([{
-      ttl: 60000,
-      limit: 100,
-    }]),
+    ThrottlerModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => [{
+        ttl: configService.get<number>('THROTTLE_TTL', 60000),
+        limit: configService.get<number>('THROTTLE_LIMIT', 100),
+      }],
+    }),
 
     UserModule,
     AdminModule,

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -17,6 +17,8 @@ import { EmailModule } from './email/email.module';
 import { MigrationModule } from './migration/migration.module';
 import { PredictionModule } from './prediction/prediction.module';
 import { CartModule } from './carts/cart.module';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 
 @Module({
   imports: [
@@ -33,6 +35,12 @@ import { CartModule } from './carts/cart.module';
       inject: [ConfigService],
     }),
 
+    // Rate limiting global: 100 requests por 60 segundos por IP
+    ThrottlerModule.forRoot([{
+      ttl: 60000,
+      limit: 100,
+    }]),
+
     UserModule,
     AdminModule,
     ProductModule,
@@ -48,6 +56,12 @@ import { CartModule } from './carts/cart.module';
     CartModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/server/src/users/user.controller.ts
+++ b/server/src/users/user.controller.ts
@@ -13,6 +13,7 @@ import { diskStorage } from 'multer';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { Throttle } from '@nestjs/throttler';
 
 @ApiTags('Users')
 @Controller('user')
@@ -35,6 +36,7 @@ export class UserController {
     }
 
     @Post('register')
+    @Throttle({ default: { limit: 3, ttl: 60000 } })
     @ApiOperation({ summary: 'Register a new user' })
     @ApiBody({ type: RegisterUserDto })
     @ApiResponse({
@@ -58,7 +60,7 @@ export class UserController {
                 user,
                 token,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(error.status || HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,
@@ -67,6 +69,7 @@ export class UserController {
     }
 
     @Post('login')
+    @Throttle({ default: { limit: 5, ttl: 60000 } })
     @ApiOperation({ summary: 'Login user' })
     @ApiBody({ type: UserLoginDto })
     @ApiResponse({
@@ -95,7 +98,7 @@ export class UserController {
                 token,
                 isAdmin,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(error.status || HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,
@@ -125,7 +128,7 @@ export class UserController {
                 success: true,
                 message: result.message,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,
@@ -156,7 +159,7 @@ export class UserController {
                 user: result.user,
                 isAdmin: result.isAdmin,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(error.status || HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,
@@ -184,7 +187,7 @@ export class UserController {
                 success: true,
                 user: result.user,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(error.status || HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,
@@ -242,7 +245,7 @@ export class UserController {
                 message: result.message,
                 user: result.user,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(error.status || HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,
@@ -251,6 +254,7 @@ export class UserController {
     }
 
     @Post('forgot-password')
+    @Throttle({ default: { limit: 3, ttl: 60000 } })
     @ApiOperation({
         summary: 'Request password reset',
         description: 'Sends a password reset link to the user\'s email. Link expires in 1 hour.'
@@ -282,7 +286,7 @@ export class UserController {
                 success: true,
                 message: result.message,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,
@@ -291,6 +295,7 @@ export class UserController {
     }
 
     @Post('reset-password')
+    @Throttle({ default: { limit: 5, ttl: 60000 } })
     @ApiOperation({
         summary: 'Reset password',
         description: 'Resets user password using the token from email'
@@ -324,7 +329,7 @@ export class UserController {
                 success: true,
                 message: result.message,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(error.status || HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,


### PR DESCRIPTION
- Install @nestjs/throttler@^6.4.0
- Configure ThrottlerModule with global limit of 100 req/min per IP
- Register ThrottlerGuard as APP_GUARD for global enforcement
- Apply stricter limits to sensitive endpoints:
  - POST /user/register: 3 req/min
  - POST /user/login: 5 req/min
  - POST /user/forgot-password: 3 req/min
  - POST /user/reset-password: 5 req/min
  - POST /admin/login: 5 req/min

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request rate limiting across the application to help prevent excessive traffic.
  * Added stricter limits for administrator login and user authentication endpoints, including registration, login, and password recovery.
* **Configuration**
  * Added configurable throttling settings for the request window and maximum requests per IP address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->