### PR TITLE
feat(pagination): add offset/limit pagination to all listing endpoints

### DIFF
--- a/server/src/common/dto/pagination.dto.ts
+++ b/server/src/common/dto/pagination.dto.ts
@@ -1,0 +1,30 @@
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class PaginationDto {
+    @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1, minimum: 1 })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    page?: number = 1;
+
+    @ApiPropertyOptional({ description: 'Items per page', default: 20, minimum: 1, maximum: 100 })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(100)
+    limit?: number = 20;
+}
+
+export interface PaginatedResult<T> {
+    data: T[];
+    pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        totalPages: number;
+    };
+}

--- a/server/src/loans/loan.controller.ts
+++ b/server/src/loans/loan.controller.ts
@@ -7,6 +7,7 @@ import type { Response } from 'express';
 import { LoanStatsResponseDto } from './dto/loan-stats-response.dto';
 import { CreateLoanDto } from './dto/create-loan.dto';
 import { AdminAuthGuard } from 'src/common/guards/admin-auth/admin-auth.guard';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
 
 // Custom decorator to skip class-level guards
 export const SkipAuthGuard = () => SetMetadata('skipAuthGuard', true);
@@ -35,14 +36,14 @@ export class LoanController {
             }
         }
     })
-    async getUserHistory(@UserId() userId: string, @Res() res: Response) {
+    async getUserHistory(@UserId() userId: string, @Query() pagination: PaginationDto, @Res() res: Response) {
         try {
-            const history = await this.loanService.getUserLoanHistory(userId);
+            const result = await this.loanService.getUserLoanHistory(userId, pagination);
 
             return res.status(HttpStatus.OK).json({
                 success: true,
-                count: history.length,
-                loans: history,
+                loans: result.data,
+                pagination: result.pagination,
             });
         } catch (error: any) {
             return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
@@ -207,14 +208,14 @@ export class LoanController {
         }
     })
     @ApiResponse({ status: 401, description: 'Unauthorized - Admin access required' })
-    async getAllLoans(@Res() res: Response) {
+    async getAllLoans(@Query() pagination: PaginationDto, @Res() res: Response) {
         try {
-            const loans = await this.loanService.getAllLoans();
+            const result = await this.loanService.getAllLoans(pagination);
 
             return res.status(HttpStatus.OK).json({
                 success: true,
-                count: loans.length,
-                loans,
+                loans: result.data,
+                pagination: result.pagination,
             });
         } catch (error: any) {
             return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({

--- a/server/src/loans/loan.service.ts
+++ b/server/src/loans/loan.service.ts
@@ -8,6 +8,7 @@ import { ReservationService } from 'src/reservations/reservation.service';
 import { Product } from 'src/products/schemas/product.schema';
 import { PredictionClient } from 'src/prediction/prediction-client.service';
 import { EmailService } from 'src/email/email.service';
+import { PaginatedResult, PaginationDto } from 'src/common/dto/pagination.dto';
 
 @Injectable()
 export class LoanService {
@@ -26,16 +27,29 @@ export class LoanService {
     /**
      * STACK (LIFO) - Obtiene historial de préstamos del usuario
      */
-    async getUserLoanHistory(userId: string): Promise<Loan[]> {
+    async getUserLoanHistory(userId: string, pagination: PaginationDto = {}): Promise<PaginatedResult<Loan>> {
         try {
-            const loans = await this.loanModel
-                .find({ userId: new Types.ObjectId(userId) })
-                .populate('bookId')
-                .sort({ loanDate: -1 })
-                .exec();
+            const { page = 1, limit = 20 } = pagination;
+            const skip = (page - 1) * limit;
+            const filter = { userId: new Types.ObjectId(userId) };
 
-            this.logger.log(`Retrieved ${loans.length} loans for user (LIFO order)`);
-            return loans;
+            const [data, total] = await Promise.all([
+                this.loanModel
+                    .find(filter)
+                    .populate('bookId')
+                    .sort({ loanDate: -1 })
+                    .skip(skip)
+                    .limit(limit)
+                    .lean()
+                    .exec(),
+                this.loanModel.countDocuments(filter),
+            ]);
+
+            this.logger.log(`Retrieved ${data.length} loans for user (page ${page}, total: ${total})`);
+            return {
+                data,
+                pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+            };
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }
@@ -488,17 +502,29 @@ export class LoanService {
     /**
      * Obtiene TODOS los préstamos del sistema (Admin only)
      */
-    async getAllLoans(): Promise<Loan[]> {
+    async getAllLoans(pagination: PaginationDto = {}): Promise<PaginatedResult<Loan>> {
         try {
-            const loans = await this.loanModel
-                .find()
-                .populate('bookId')
-                .populate('userId')
-                .sort({ loanDate: -1 })
-                .exec();
+            const { page = 1, limit = 20 } = pagination;
+            const skip = (page - 1) * limit;
 
-            this.logger.log(`Retrieved ${loans.length} total loans`);
-            return loans;
+            const [data, total] = await Promise.all([
+                this.loanModel
+                    .find()
+                    .populate('bookId')
+                    .populate('userId')
+                    .sort({ loanDate: -1 })
+                    .skip(skip)
+                    .limit(limit)
+                    .lean()
+                    .exec(),
+                this.loanModel.countDocuments(),
+            ]);
+
+            this.logger.log(`Retrieved ${data.length} loans (page ${page}, total: ${total})`);
+            return {
+                data,
+                pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+            };
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }

--- a/server/src/orders/order.controller.ts
+++ b/server/src/orders/order.controller.ts
@@ -8,6 +8,7 @@ import type { Response } from 'express';
 import { AdminAuthGuard } from 'src/common/guards/admin-auth/admin-auth.guard';
 import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
 import { PlaceOrderStripeDto } from './dto/place-order-stripe.dto';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
 
 @ApiTags('Orders')
 @Controller('order')
@@ -106,13 +107,14 @@ export class OrderController {
         description: 'Orders retrieved successfully',
     })
     @ApiResponse({ status: 401, description: 'Unauthorized' })
-    async userOrders(@UserId() userId: string, @Res() res: Response) {
+    async userOrders(@UserId() userId: string, @Query() pagination: PaginationDto, @Res() res: Response) {
         try {
-            const orders = await this.orderService.userOrders(userId);
+            const result = await this.orderService.userOrders(userId, pagination);
 
             return res.status(HttpStatus.OK).json({
                 success: true,
-                orders,
+                orders: result.data,
+                pagination: result.pagination,
             });
         } catch (error: any) {
             return res
@@ -134,13 +136,14 @@ export class OrderController {
         description: 'Orders retrieved successfully',
     })
     @ApiResponse({ status: 401, description: 'Unauthorized' })
-    async allOrders(@Res() res: Response) {
+    async allOrders(@Query() pagination: PaginationDto, @Res() res: Response) {
         try {
-            const orders = await this.orderService.allOrders();
+            const result = await this.orderService.allOrders(pagination);
 
             return res.status(HttpStatus.OK).json({
                 success: true,
-                orders,
+                orders: result.data,
+                pagination: result.pagination,
             });
         } catch (error: any) {
             return res

--- a/server/src/orders/order.service.ts
+++ b/server/src/orders/order.service.ts
@@ -10,6 +10,7 @@ import Stripe from 'stripe';
 import { ConfigService } from '@nestjs/config';
 import { PlaceOrderStripeDto } from './dto/place-order-stripe.dto';
 import { OrderSchedulerService } from './services/order-scheduler.service';
+import { PaginatedResult, PaginationDto } from 'src/common/dto/pagination.dto';
 
 @Injectable()
 export class OrderService {
@@ -204,37 +205,61 @@ export class OrderService {
         }
     }
 
-    async userOrders(userId: string): Promise<Order[]> {
+    async userOrders(userId: string, pagination: PaginationDto = {}): Promise<PaginatedResult<Order>> {
         try {
-            const orders = await this.orderModel
-                .find({
-                    userId,
-                    $or: [{ paymentMethod: 'COD' }, { isPaid: true }],
-                })
-                .populate({
-                    path: 'items.product',
-                    model: 'Product',
-                })
-                .populate('address')
-                .sort({ createdAt: -1 });
+            const { page = 1, limit = 20 } = pagination;
+            const skip = (page - 1) * limit;
+            const filter = {
+                userId,
+                $or: [{ paymentMethod: 'COD' }, { isPaid: true }],
+            };
 
-            return orders;
+            const [data, total] = await Promise.all([
+                this.orderModel
+                    .find(filter)
+                    .populate({
+                        path: 'items.product',
+                        model: 'Product',
+                    })
+                    .populate('address')
+                    .sort({ createdAt: -1 })
+                    .skip(skip)
+                    .limit(limit)
+                    .lean(),
+                this.orderModel.countDocuments(filter),
+            ]);
+
+            return {
+                data,
+                pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+            };
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }
     }
 
-    async allOrders(): Promise<Order[]> {
+    async allOrders(pagination: PaginationDto = {}): Promise<PaginatedResult<Order>> {
         try {
-            const orders = await this.orderModel
-                .find({
-                    $or: [{ paymentMethod: 'COD' }, { isPaid: true }],
-                })
-                .populate('items.product')
-                .populate('address')
-                .sort({ createdAt: -1 });
+            const { page = 1, limit = 20 } = pagination;
+            const skip = (page - 1) * limit;
+            const filter = { $or: [{ paymentMethod: 'COD' }, { isPaid: true }] };
 
-            return orders;
+            const [data, total] = await Promise.all([
+                this.orderModel
+                    .find(filter)
+                    .populate('items.product')
+                    .populate('address')
+                    .sort({ createdAt: -1 })
+                    .skip(skip)
+                    .limit(limit)
+                    .lean(),
+                this.orderModel.countDocuments(filter),
+            ]);
+
+            return {
+                data,
+                pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+            };
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }

--- a/server/src/products/product.controller.ts
+++ b/server/src/products/product.controller.ts
@@ -9,6 +9,7 @@ import { AddProductDto } from './dto/add-product.dto';
 import { SingleProductDto } from './dto/single-product.dto';
 import { ChangeStockDto } from './dto/change-stock.dto';
 import { SearchProductDto } from './dto/search-product.dto';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
 
 @ApiTags('Product')
 @Controller('product')
@@ -80,15 +81,16 @@ export class ProductController {
     }
 
     @Get('list')
-    @ApiOperation({ summary: 'Get all products' })
+    @ApiOperation({ summary: 'Get all products with pagination' })
     @ApiResponse({ status: 200, description: 'Products retrieved successfully' })
-    async listProducts(@Res() res: Response) {
+    async listProducts(@Query() pagination: PaginationDto, @Res() res: Response) {
         try {
-            const products = await this.productService.listProducts();
+            const result = await this.productService.listProducts(pagination);;
 
             return res.status(HttpStatus.OK).json({
                 success: true,
-                products,
+                products: result.data,  // Compatibilidad: frontend lee 'products'
+                pagination: result.pagination,  // Nuevo campo: metadata de paginación
             });
         } catch (error: any) {
             return res
@@ -316,23 +318,31 @@ export class ProductController {
     })
     async searchProducts(
         @Body() dto: SearchProductDto,
+        @Query() pagination: PaginationDto,
         @Res() res: Response
     ) {
         try {
-            const { query, limit } = dto;
+            const { query } = dto;
+
+            // Backward compatibility: si viene limit en el body, usarlo como pagination limit
+            if (dto.limit && !pagination.limit) {
+                pagination.limit = dto.limit;
+            }
+
             const cleanQuery = query.replace(/-/g, '');
             const searchType: 'isbn' | 'text' = /^\d{9}[\dX]$/.test(cleanQuery) || /^\d{13}$/.test(cleanQuery)
                 ? 'isbn'
                 : 'text';
 
-            const results = await this.productService.search(query, limit);
+            const result = await this.productService.search(query, pagination);
 
             return res.status(HttpStatus.OK).json({
                 success: true,
                 query,
                 searchType,
-                count: results.length,
-                products: results,
+                count: result.pagination.total,
+                products: result.data,
+                pagination: result.pagination,
             });
         } catch (error: any) {
             return res
@@ -638,15 +648,17 @@ export class ProductController {
     @ApiResponse({ status: 200, description: 'Products retrieved with translations' })
     async listProductsWithTranslation(
         @Param('lang') lang: string,
+        @Query() pagination: PaginationDto,
         @Res() res: Response,
     ) {
         try {
-            const products = await this.productService.listProductsWithTranslation(lang);
+            const result = await this.productService.listProductsWithTranslation(lang, pagination);
 
             return res.status(HttpStatus.OK).json({
                 success: true,
                 language: lang,
-                products,
+                products: result.data,
+                pagination: result.pagination,
             });
         } catch (error: any) {
             return res

--- a/server/src/products/product.service.ts
+++ b/server/src/products/product.service.ts
@@ -7,6 +7,7 @@ import { v2 as cloudinary } from 'cloudinary';
 import { AddProductDto } from './dto/add-product.dto';
 import { ChangeStockDto } from './dto/change-stock.dto';
 import { generateISBN, estimatePageCount, assignDefaultAuthor, assignDefaultPublisher, generatePublicationYear } from './utils/migration.utils';
+import { PaginatedResult, PaginationDto } from 'src/common/dto/pagination.dto';
 
 @Injectable()
 export class ProductService {
@@ -78,9 +79,25 @@ export class ProductService {
      * Lista los productos que hay en el sistema (Inventario General)
      * @returns Lista de productos existentes
      */
-    async listProducts(): Promise<Product[]> {
+    async listProducts(pagination: PaginationDto = {}): Promise<PaginatedResult<Product>> {
         try {
-            return await this.productModel.find({});
+            const { page = 1, limit = 20 } = pagination;
+            const skip = (page - 1) * limit;
+
+            const [data, total] = await Promise.all([
+                this.productModel.find().skip(skip).limit(limit).lean(),
+                this.productModel.countDocuments(),
+            ]);
+
+            return {
+                data,
+                pagination: {
+                    page,
+                    limit,
+                    total,
+                    totalPages: Math.ceil(total / limit),
+                },
+            };
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }
@@ -160,28 +177,42 @@ export class ProductService {
      * Búsqueda unified: detecta ISBN vs texto y delega al método apropiado.
      * El cliente no necesita saber qué algoritmo se usa internamente.
      */
-    async search(query: string, limit: number = 20): Promise<Product[]> {
+    async search(query: string, pagination: PaginationDto = {}): Promise<PaginatedResult<Product>> {
+        const { page = 1, limit = 20 } = pagination;
+        const skip = (page - 1) * limit;
         const cleanQuery = query.replace(/-/g, '');
         const isIsbn = /^\d{9}[\dX]$/.test(cleanQuery) || /^\d{13}$/.test(cleanQuery);
 
         if (isIsbn) {
             const result = await this.searchByISBN(cleanQuery);
-            return result.product ? [result.product] : [];
+            const data = result.product ? [result.product] : [];
+            return {
+                data,
+                pagination: { page, limit, total: data.length, totalPages: data.length > 0 ? 1 : 0 },
+            };
         }
 
-        // Búsqueda de texto: busca en nombre Y autor simultáneamente
-        const results = await this.productModel
-            .find({
-                $or: [
-                    { name: { $regex: query, $options: 'i' } },
-                    { author: { $regex: query, $options: 'i' } }
-                ]
-            })
-            .limit(limit)
-            .lean()
-            .exec();
+        const filter = {
+            $or: [
+                { name: { $regex: query, $options: 'i' } },
+                { author: { $regex: query, $options: 'i' } }
+            ]
+        };
 
-        return results;
+        const [data, total] = await Promise.all([
+            this.productModel.find(filter).skip(skip).limit(limit).lean().exec(),
+            this.productModel.countDocuments(filter),
+        ]);
+
+        return {
+            data,
+            pagination: {
+                page,
+                limit,
+                total,
+                totalPages: Math.ceil(total / limit),
+            },
+        };
     }
 
     /**
@@ -207,7 +238,7 @@ export class ProductService {
     // Genera Reporte Global ordenado por valor usando Merge Sort
     async generateValueReport(ascending: boolean = true): Promise<Product[]> {
         try {
-            const products = await this.listProducts();
+            const products = await this.productModel.find({}).lean();
             const sortedProducts = this.mergeSortByValue(products, ascending);
             console.log(`[ProductService] Value report: ${sortedProducts.length} products (${ascending ? 'ASC' : 'DESC'})`);
             return sortedProducts;
@@ -453,11 +484,29 @@ export class ProductService {
      * Obtiene productos con traducciones aplicadas según el idioma solicitado
      * @param lang - Código de idioma (es, en, etc.)
      */
-    async listProductsWithTranslation(lang: string = 'en'): Promise<Product[]> {
+    async listProductsWithTranslation(lang: string = 'en', pagination: PaginationDto = {}): Promise<PaginatedResult<Product>> {
         try {
-            const products = await this.productModel.find({});
-            if (lang === 'en') return products;
-            return products.map((product) => this.applyTranslation(product, lang));
+            const { page = 1, limit = 20 } = pagination;
+            const skip = (page - 1) * limit;
+
+            const [rawProducts, total] = await Promise.all([
+                this.productModel.find().skip(skip).limit(limit).lean(),
+                this.productModel.countDocuments(),
+            ]);
+
+            const data = lang === 'en'
+                ? rawProducts
+                : rawProducts.map((product) => this.applyTranslation(product, lang));
+
+            return {
+                data,
+                pagination: {
+                    page,
+                    limit,
+                    total,
+                    totalPages: Math.ceil(total / limit),
+                },
+            };
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }

--- a/server/src/products/product.service.ts
+++ b/server/src/products/product.service.ts
@@ -185,10 +185,11 @@ export class ProductService {
 
         if (isIsbn) {
             const result = await this.searchByISBN(cleanQuery);
-            const data = result.product ? [result.product] : [];
+            const total = result.product ? 1 : 0;
+            const data = result.product && page === 1 ? [result.product] : [];
             return {
                 data,
-                pagination: { page, limit, total: data.length, totalPages: data.length > 0 ? 1 : 0 },
+                pagination: { page, limit, total, totalPages: total },
             };
         }
 
@@ -490,7 +491,7 @@ export class ProductService {
             const skip = (page - 1) * limit;
 
             const [rawProducts, total] = await Promise.all([
-                this.productModel.find().skip(skip).limit(limit).lean(),
+                this.productModel.find().skip(skip).limit(limit),
                 this.productModel.countDocuments(),
             ]);
 

--- a/server/src/reservations/reservation.controller.ts
+++ b/server/src/reservations/reservation.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, HttpStatus, Param, Post, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpStatus, Param, Post, Query, Res, UseGuards } from '@nestjs/common';
 import { ApiBody, ApiCookieAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ReservationService } from './reservation.service';
 import { AuthGuard } from 'src/common/guards/auth/auth.guard';
@@ -6,6 +6,7 @@ import { UserId } from 'src/common/decorators/users/user-id.decorator';
 import type { Response } from 'express';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 import { ReservationStatsResponseDto } from './dto/reservation-stats-response.dto';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
 
 @ApiTags('Reservations')
 @Controller('reservation')
@@ -49,7 +50,7 @@ export class ReservationController {
                 message: `Added to waiting list at position ${reservation.priority}`,
                 reservation,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(HttpStatus.BAD_REQUEST).json({
                 success: false,
                 message: error.message,
@@ -75,16 +76,16 @@ export class ReservationController {
             }
         }
     })
-    async getWaitingList(@Param('bookId') bookId: string, @Res() res: Response) {
+    async getWaitingList(@Param('bookId') bookId: string, @Query() pagination: PaginationDto, @Res() res: Response) {
         try {
-            const waitingList = await this.reservationService.getWaitingList(bookId);
+            const result = await this.reservationService.getWaitingList(bookId, pagination);
 
             return res.status(HttpStatus.OK).json({
                 success: true,
-                count: waitingList.length,
-                waitingList,
+                waitingList: result.data,
+                pagination: result.pagination,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,
@@ -125,7 +126,7 @@ export class ReservationController {
                 message: 'Reservation cancelled successfully',
                 reservation,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(HttpStatus.BAD_REQUEST).json({
                 success: false,
                 message: error.message,
@@ -148,7 +149,7 @@ export class ReservationController {
                 success: true,
                 stats,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,
@@ -173,16 +174,16 @@ export class ReservationController {
             }
         }
     })
-    async getUserReservationList(@UserId() userId: string, @Res() res: Response) {
+    async getUserReservationList(@UserId() userId: string, @Query() pagination: PaginationDto, @Res() res: Response) {
         try {
-            const reservations = await this.reservationService.getUserReservationList(userId);
+            const result = await this.reservationService.getUserReservationList(userId, pagination);
 
             return res.status(HttpStatus.OK).json({
                 success: true,
-                count: reservations.length,
-                reservations,
+                reservations: result.data,
+                pagination: result.pagination,
             });
-        } catch (error) {
+        } catch (error: any) {
             return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: error.message,

--- a/server/src/reservations/reservation.service.ts
+++ b/server/src/reservations/reservation.service.ts
@@ -5,6 +5,7 @@ import { Reservation, ReservationDocument } from './schemas/reservation.schema';
 import { Loan, LoanDocument } from 'src/loans/schemas/loan.schema';
 import { ProductService } from 'src/products/product.service';
 import { PredictionClient } from 'src/prediction/prediction-client.service';
+import { PaginatedResult, PaginationDto } from 'src/common/dto/pagination.dto';
 
 /**
  * Interfaz para los datos de historial de préstamos del usuario.
@@ -196,20 +197,33 @@ export class ReservationService {
     /**
      * Obtiene toda la cola de espera para un libro
      */
-    async getWaitingList(bookId: string): Promise<Reservation[]> {
+    async getWaitingList(bookId: string, pagination: PaginationDto = {}): Promise<PaginatedResult<Reservation>> {
         try {
-            const waitingList = await this.reservationModel
-                .find({
-                    bookId: new Types.ObjectId(bookId),
-                    status: 'pending'
-                })
-                .sort({ priority: 1 })
-                .populate('userId')
-                .exec();
+            const { page = 1, limit = 20 } = pagination;
+            const skip = (page - 1) * limit;
+            const filter = {
+                bookId: new Types.ObjectId(bookId),
+                status: 'pending'
+            };
 
-            this.logger.log(`Waiting list for book ${bookId}: ${waitingList.length} reservations`);
+            const [data, total] = await Promise.all([
+                this.reservationModel
+                    .find(filter)
+                    .sort({ priority: 1 })
+                    .populate('userId')
+                    .skip(skip)
+                    .limit(limit)
+                    .lean()
+                    .exec(),
+                this.reservationModel.countDocuments(filter),
+            ]);
 
-            return waitingList;
+            this.logger.log(`Waiting list for book ${bookId}: ${data.length} reservations (page ${page}, total: ${total})`);
+
+            return {
+                data,
+                pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+            };
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }
@@ -300,16 +314,29 @@ export class ReservationService {
     /**
      * Obtiene la lista completa de reservas de un usuario con detalles del libro
      */
-    async getUserReservationList(userId: string): Promise<Reservation[]> {
+    async getUserReservationList(userId: string, pagination: PaginationDto = {}): Promise<PaginatedResult<Reservation>> {
         try {
-            const reservations = await this.reservationModel
-                .find({ userId: new Types.ObjectId(userId) })
-                .populate('bookId')
-                .sort({ requestDate: -1 })
-                .exec();
+            const { page = 1, limit = 20 } = pagination;
+            const skip = (page - 1) * limit;
+            const filter = { userId: new Types.ObjectId(userId) };
 
-            this.logger.log(`Retrieved ${reservations.length} reservations for user ${userId}`);
-            return reservations;
+            const [data, total] = await Promise.all([
+                this.reservationModel
+                    .find(filter)
+                    .populate('bookId')
+                    .sort({ requestDate: -1 })
+                    .skip(skip)
+                    .limit(limit)
+                    .lean()
+                    .exec(),
+                this.reservationModel.countDocuments(filter),
+            ]);
+
+            this.logger.log(`Retrieved ${data.length} reservations for user ${userId} (page ${page}, total: ${total})`);
+            return {
+                data,
+                pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+            };
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }

--- a/server/src/shelves/shelf.controller.ts
+++ b/server/src/shelves/shelf.controller.ts
@@ -5,6 +5,7 @@ import { AdminAuthGuard } from 'src/common/guards/admin-auth/admin-auth.guard';
 import { CreateShelfDto } from './dtos/create-shelf.dto';
 import type { Response } from 'express';
 import { AssignBookDto } from './dtos/assign-book.dto';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
 
 @ApiTags('Shelf')
 @Controller('shelf')
@@ -44,14 +45,14 @@ export class ShelfController {
         status: 200,
         description: 'Shelves retrieved successfully',
     })
-    async listShelves(@Res() res: Response) {
+    async listShelves(@Query() pagination: PaginationDto, @Res() res: Response) {
         try {
-            const shelves = await this.shelfService.listShelves();
+            const result = await this.shelfService.listShelves(pagination);
 
             return res.status(HttpStatus.OK).json({
                 success: true,
-                count: shelves.length,
-                shelves,
+                shelves: result.data,
+                pagination: result.pagination,
             });
         } catch (error: any) {
             return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({

--- a/server/src/shelves/shelf.service.ts
+++ b/server/src/shelves/shelf.service.ts
@@ -6,6 +6,7 @@ import { Model, Types } from 'mongoose';
 import { Product, ProductDocument } from 'src/products/schemas/product.schema';
 import { Loan, LoanDocument } from 'src/loans/schemas/loan.schema';
 import { CreateShelfDto } from './dtos/create-shelf.dto';
+import { PaginatedResult, PaginationDto } from 'src/common/dto/pagination.dto';
 
 @Injectable()
 export class ShelfService {
@@ -59,15 +60,27 @@ export class ShelfService {
     /**
      * Listar todas las estanterías
      */
-    async listShelves(): Promise<Shelf[]> {
+    async listShelves(pagination: PaginationDto = {}): Promise<PaginatedResult<Shelf>> {
         try {
-            const shelves = await this.shelfModel
-                .find()
-                .populate('books')
-                .sort({ code: 1 })
-                .exec();
+            const { page = 1, limit = 20 } = pagination;
+            const skip = (page - 1) * limit;
 
-            return shelves;
+            const [data, total] = await Promise.all([
+                this.shelfModel
+                    .find()
+                    .populate('books')
+                    .sort({ code: 1 })
+                    .skip(skip)
+                    .limit(limit)
+                    .lean()
+                    .exec(),
+                this.shelfModel.countDocuments(),
+            ]);
+
+            return {
+                data,
+                pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+            };
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }


### PR DESCRIPTION
- Create shared PaginationDto (page/limit) in common/dto/pagination.dto.ts
- Add pagination to product, order, loan, reservation and shelf services
- Update all controllers to accept @Query() PaginationDto
- Return PaginatedResult with data[] + pagination metadata
- Preserve backward compatibility: params optional, defaults page=1 limit=20
- Fix generateValueReport() to query directly instead of via listProducts()

Affected endpoints:
  GET  /api/product/list GET  /api/product/list/:lang POST /api/product/search POST /api/order/list POST /api/order/user-orders GET  /api/loan/admin/all GET  /api/loan/history GET  /api/reservation/user-list GET  /api/reservation/waiting-list/:bookId GET  /api/shelf/list

Closes #205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination to product listings and searches, including translated product results.
  * Added pagination to loan, order, reservation, waiting-list, and shelf listings.
  * List responses now include page data alongside metadata such as current page, page size, total items, and total pages.
  * Added validated page and limit controls with sensible defaults and maximum limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->