### PR TITLE
perf(db): add MongoDB indexes for frequently queried fields

### DIFF
--- a/server/src/addresses/schemas/address.schema.ts
+++ b/server/src/addresses/schemas/address.schema.ts
@@ -37,3 +37,6 @@ export class Address {
 }
 
 export const AddressSchema = SchemaFactory.createForClass(Address);
+
+// Índice compuesto para getAddresses(): find({userId}).sort({createdAt: -1})
+AddressSchema.index({ userId: 1, createdAt: -1 });

--- a/server/src/orders/schemas/order.schema.ts
+++ b/server/src/orders/schemas/order.schema.ts
@@ -45,3 +45,12 @@ export class Order {
 }
 
 export const OrderSchema = SchemaFactory.createForClass(Order);
+
+// Índice compuesto para userOrders(): filtra por userId + sort por createdAt
+OrderSchema.index({ userId: 1, createdAt: -1 });
+
+// Índice para rebuildQueue(): filtra por status
+OrderSchema.index({ status: 1 });
+
+// Índice para allOrders(): sort por createdAt sin filtro de usuario
+OrderSchema.index({ createdAt: -1 });

--- a/server/src/products/schemas/product.schema.ts
+++ b/server/src/products/schemas/product.schema.ts
@@ -97,3 +97,6 @@ export class Product {
 }
 
 export const ProductSchema = SchemaFactory.createForClass(Product);
+
+// Índice para filtrado por categoría (reportes, cálculos recursivos)
+ProductSchema.index({ category: 1 });

--- a/server/src/reservations/schemas/reservation.schema.ts
+++ b/server/src/reservations/schemas/reservation.schema.ts
@@ -38,3 +38,9 @@ export class Reservation {
 }
 
 export const ReservationSchema = SchemaFactory.createForClass(Reservation);
+
+// Índice compuesto para la cola de espera: find({bookId, status}).sort({priority})
+ReservationSchema.index({ bookId: 1, status: 1, priority: 1 });
+
+// Índice compuesto para getUserReservationList(): find({userId}).sort({requestDate: -1})
+ReservationSchema.index({ userId: 1, requestDate: -1 });


### PR DESCRIPTION
Add explicit indexes to Order, Reservation, Address, and Product schemas to eliminate full collection scans on high-traffic queries.

- Order: userId+createdAt (userOrders), status (rebuildQueue), createdAt (allOrders)
- Reservation: bookId+status+priority (waiting queue), userId+requestDate (user history)
- Address: userId+createdAt (getAddresses)
- Product: category (reports and filters)

Closes: #206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved the responsiveness of address, order, product, and reservation lookups.
  * Optimized sorting and filtering for recent records, categories, statuses, user-specific lists, and waiting queues.
  * Enhanced order retrieval and reservation queue processing for more efficient data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->