### PR TITLE
feat(cache): implement Redis distributed cache with @nestjs/cache-man…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,15 +32,21 @@ services:
         redis:7-alpine
     ports:
       - "4000:4000"
-      - "6379:6379"
-    volumes:
-      - redis_data:/data
     environment:
       MONGODB_URI: mongodb://mongodb:27017
       ML_SERVICE_URL: http://zibooka-ml:5000
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
     depends_on:
       - mongodb
       - redis
+  redis:
+    image: redis:7-alpine
+    container_name: zibooka-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
 
 volumes:
   mongodb_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,13 +28,19 @@ services:
   zibooka-backend:
     build: ./server
     container_name: zibooka-backend
+    image: 
+        redis:7-alpine
     ports:
       - "4000:4000"
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
     environment:
       MONGODB_URI: mongodb://mongodb:27017
       ML_SERVICE_URL: http://zibooka-ml:5000
     depends_on:
       - mongodb
+      - redis
 
 volumes:
   mongodb_data:

--- a/server/.env.example
+++ b/server/.env.example
@@ -23,3 +23,5 @@ RESERVATION_SCORE_DELTA=0.1    # Penalización por devoluciones tardías
 LOAN_FEE_ESTIMATE=5.00  # Fee estimado por préstamo para optimización del carrito
 THROTTLE_TTL=60000        # Ventana de tiempo en milisegundos (default: 60000 = 1 min)
 THROTTLE_LIMIT=100        # Maximo de requests por ventana por IP (default: 100)
+REDIS_HOST=localhost
+REDIS_PORT=6379

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/cache-manager": "^3.1.3",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
@@ -28,6 +29,8 @@
     "@nestjs/swagger": "^11.2.5",
     "@nestjs/throttler": "^6.5.0",
     "bcryptjs": "^3.0.3",
+    "cache-manager": "^7.2.9",
+    "cache-manager-ioredis-yet": "^2.1.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
     "cloudinary": "^2.8.0",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@nestjs/cache-manager':
+        specifier: ^3.1.3
+        version: 3.1.3(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(cache-manager@7.2.9)(keyv@5.6.0)(rxjs@7.8.2)
       '@nestjs/common':
         specifier: ^11.0.1
         version: 11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -32,6 +35,12 @@ importers:
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
+      cache-manager:
+        specifier: ^7.2.9
+        version: 7.2.9
+      cache-manager-ioredis-yet:
+        specifier: ^2.1.2
+        version: 2.1.2
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -360,6 +369,9 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
+  '@cacheable/utils@2.5.0':
+    resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -584,6 +596,9 @@ packages:
       '@types/node':
         optional: true
 
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -700,6 +715,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
@@ -715,6 +733,15 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nestjs/cache-manager@3.1.3':
+    resolution: {integrity: sha512-HMtiOfHz75NZX7mJn1VnZGLSachVI04TnUc5wvEogIaKwk5BDQHgtP5htxreizjv7oxKalJbuTyxtiF6bE+bgQ==}
+    peerDependencies:
+      '@nestjs/common': ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^9.0.0 || ^10.0.0 || ^11.0.0
+      cache-manager: '>=6'
+      keyv: '>=5'
+      rxjs: ^7.8.1
 
   '@nestjs/cli@11.0.21':
     resolution: {integrity: sha512-F8mV0Sj/zVEouzR3NxBuJy08YHTUOmC5Xdcx3qIIaJWzrm8Vw86CHkhkaPBJ5ewRMHPDCShPmhsfwhpCcjts3A==}
@@ -1516,6 +1543,14 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cache-manager-ioredis-yet@2.1.2:
+    resolution: {integrity: sha512-p/5D+ADvJaZjAs12fR5l0ZJ+rK2EqbCryFdrzsMj3K+lGwNoCjB33N6V397otgreB+iwK+lssBshpkJDodiyMQ==}
+    engines: {node: '>= 18'}
+    deprecated: With cache-manager v6 we now are using Keyv
+
+  cache-manager@7.2.9:
+    resolution: {integrity: sha512-d4vceEyYe95gPxEyQchlEOH9vJlkNRW8G6gzFzzMTxJK9PahYMhC9chrEqgZN0HulROjgw3IzmWVNk7Q7ytiGw==}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1605,6 +1640,10 @@ packages:
   cloudinary@2.10.0:
     resolution: {integrity: sha512-sY09kYg7wprkndAOjZBAYqFZqwL+SxnEGcAvksOvFA+5upnFn949UjkEkHKNSwkBtW/xRDd0p6NgbSXZcxkI3w==}
     engines: {node: '>=9'}
+
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -2173,9 +2212,16 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -2225,6 +2271,10 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ioredis@5.11.1:
+    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
+    engines: {node: '>=12.22.0'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -2502,6 +2552,9 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
@@ -2643,6 +2696,9 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  map-or-similar@1.5.0:
+    resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2658,6 +2714,9 @@ packages:
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
+
+  memoizerific@1.11.3:
+    resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
 
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
@@ -3018,6 +3077,14 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
@@ -3177,6 +3244,9 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -3274,6 +3344,9 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  telejson@7.2.0:
+    resolution: {integrity: sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==}
 
   terser-webpack-plugin@5.6.0:
     resolution: {integrity: sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==}
@@ -3859,6 +3932,11 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@cacheable/utils@2.5.0':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -4103,6 +4181,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
+  '@ioredis/commands@1.10.0': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -4329,6 +4409,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@keyv/serialize@1.1.1': {}
+
   '@lukeed/csprng@1.1.0': {}
 
   '@microsoft/tsdoc@0.16.0': {}
@@ -4343,6 +4425,14 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@nestjs/cache-manager@3.1.3(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.21)(cache-manager@7.2.9)(keyv@5.6.0)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.21(@nestjs/common@11.1.21(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.21)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cache-manager: 7.2.9
+      keyv: 5.6.0
+      rxjs: 7.8.2
 
   '@nestjs/cli@11.0.21(@types/node@25.9.1)(prettier@3.8.3)':
     dependencies:
@@ -5229,6 +5319,19 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cache-manager-ioredis-yet@2.1.2:
+    dependencies:
+      cache-manager: 7.2.9
+      ioredis: 5.11.1
+      telejson: 7.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  cache-manager@7.2.9:
+    dependencies:
+      '@cacheable/utils': 2.5.0
+      keyv: 5.6.0
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -5305,6 +5408,8 @@ snapshots:
   cloudinary@2.10.0:
     dependencies:
       lodash: 4.18.1
+
+  cluster-key-slot@1.1.1: {}
 
   co@4.6.0: {}
 
@@ -5904,9 +6009,15 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
+
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  hookified@1.15.1: {}
 
   html-escaper@2.0.2: {}
 
@@ -5950,6 +6061,18 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ioredis@5.11.1:
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ipaddr.js@1.9.1: {}
 
@@ -6410,6 +6533,10 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
@@ -6521,6 +6648,8 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  map-or-similar@1.5.0: {}
+
   math-intrinsics@1.1.0: {}
 
   media-typer@0.3.0: {}
@@ -6530,6 +6659,10 @@ snapshots:
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.1.0
+
+  memoizerific@1.11.3:
+    dependencies:
+      map-or-similar: 1.5.0
 
   memory-pager@1.5.0: {}
 
@@ -6854,6 +6987,12 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   reflect-metadata@0.2.2: {}
 
   require-directory@2.1.1: {}
@@ -7023,6 +7162,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  standard-as-callback@2.1.0: {}
+
   statuses@2.0.2: {}
 
   streamsearch@1.1.0: {}
@@ -7125,6 +7266,10 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  telejson@7.2.0:
+    dependencies:
+      memoizerific: 1.11.3
 
   terser-webpack-plugin@5.6.0(webpack@5.106.0):
     dependencies:

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -19,6 +19,8 @@ import { PredictionModule } from './prediction/prediction.module';
 import { CartModule } from './carts/cart.module';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
+import { CacheModule } from '@nestjs/cache-manager';
+import { redisStore } from 'cache-manager-ioredis-yet';
 
 @Module({
   imports: [
@@ -33,6 +35,31 @@ import { APP_GUARD } from '@nestjs/core';
       imports: [ConfigModule],
       useFactory: getMongoConfig,
       inject: [ConfigService],
+    }),
+
+    // Cache distribuido: Redis con fallback a memoria
+    CacheModule.registerAsync({
+      isGlobal: true,
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => {
+        const redisHost = configService.get<string>('REDIS_HOST');
+        const redisPort = configService.get<number>('REDIS_PORT');
+
+        if (redisHost) {
+          return {
+            store: await redisStore({
+              host: redisHost,
+              port: redisPort || 6379,
+              ttl: 60, // 60 segundos por defecto
+            }),
+          };
+        }
+
+        // Fallback a caché en memoria si Redis no está configurado
+        console.log('[CacheModule] Redis not configured, using in-memory cache');
+        return { ttl: 60 };
+      },
     }),
 
     // Rate limiting global: 100 requests por 60 segundos por IP

--- a/server/src/loans/loan.service.ts
+++ b/server/src/loans/loan.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException, Logger } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, InternalServerErrorException, NotFoundException, Logger } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Loan, LoanDocument } from './schemas/loan.schema';
 import { HighRiskLoan, HighRiskLoanDocument } from './schemas/high-risk-loan.schema';
@@ -9,6 +9,8 @@ import { Product } from 'src/products/schemas/product.schema';
 import { PredictionClient } from 'src/prediction/prediction-client.service';
 import { EmailService } from 'src/email/email.service';
 import { PaginatedResult, PaginationDto } from 'src/common/dto/pagination.dto';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 
 @Injectable()
 export class LoanService {
@@ -22,6 +24,7 @@ export class LoanService {
         private reservationService: ReservationService,
         private predictionClient: PredictionClient,
         private emailService: EmailService,
+        @Inject(CACHE_MANAGER) private cacheManager: Cache,
     ) { }
 
     /**
@@ -113,6 +116,9 @@ export class LoanService {
             // Actualizar el stock del libro (producto)
             book.inStock = false;
             await book.save();
+
+            // Invalidar caché de estadísticas del usuario
+            await this.cacheManager.del(`loan:stats:${userId}`);
 
             this.logger.log(`Loan created: ${newLoan._id} | riskScore: ${riskScore.toFixed(4)}`);
             return newLoan;
@@ -434,6 +440,10 @@ export class LoanService {
 
             await loan.save();
 
+            // Invalidar caché de estadísticas del usuario
+            const userIdStr = (loan.userId as any)._id?.toString() || loan.userId.toString();
+            await this.cacheManager.del(`loan:stats:${userIdStr}`);
+
             const bookId = (loan.bookId as any)._id.toString();
             let assignedToReservation = false;
             let reservationInfo: {
@@ -483,6 +493,19 @@ export class LoanService {
      */
     async getUserLoanStats(userId: string) {
         try {
+            const cacheKey = `loan:stats:${userId}`;
+
+            // Intentar obtener del caché
+            const cached = await this.cacheManager.get<{
+                total: number;
+                active: number;
+                completed: number;
+                overdue: number;
+            }>(cacheKey);
+            if (cached) {
+                return cached;
+            }
+
             const loans = await this.loanModel.find({ userId: new Types.ObjectId(userId) });
 
             const stats = {
@@ -491,6 +514,9 @@ export class LoanService {
                 completed: loans.filter(l => l.status === 'completed').length,
                 overdue: loans.filter(l => l.status === 'overdue').length,
             };
+
+            // Guardar en caché por 5 minutos
+            await this.cacheManager.set(cacheKey, stats, 300);
 
             this.logger.log(`Loan stats for user ${userId}:`, stats);
             return stats;

--- a/server/src/orders/order.service.ts
+++ b/server/src/orders/order.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Order, OrderDocument } from './schemas/order.schema';
 import { Model, Types } from 'mongoose';
@@ -11,6 +11,8 @@ import { ConfigService } from '@nestjs/config';
 import { PlaceOrderStripeDto } from './dto/place-order-stripe.dto';
 import { OrderSchedulerService } from './services/order-scheduler.service';
 import { PaginatedResult, PaginationDto } from 'src/common/dto/pagination.dto';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 
 @Injectable()
 export class OrderService {
@@ -27,6 +29,7 @@ export class OrderService {
         @InjectModel(User.name) private userModel: Model<UserDocument>,
         private configService: ConfigService,
         private readonly orderScheduler: OrderSchedulerService,
+        @Inject(CACHE_MANAGER) private cacheManager: Cache,
     ) {
         // Initialize Stripe
         const stripeSecretKey = this.configService.get<string>('STRIPE_SECRET_KEY');
@@ -96,7 +99,7 @@ export class OrderService {
         userId: string,
         placeOrderDto: PlaceOrderStripeDto,
         origin: string,
-    ): Promise<{ success: boolean; url?: string; message?: string }> { 
+    ): Promise<{ success: boolean; url?: string; message?: string }> {
         try {
             const { items, address } = placeOrderDto;
 
@@ -208,6 +211,14 @@ export class OrderService {
     async userOrders(userId: string, pagination: PaginationDto = {}): Promise<PaginatedResult<Order>> {
         try {
             const { page = 1, limit = 20 } = pagination;
+            const cacheKey = `orders:user:${userId}:${page}:${limit}`;
+
+            // Intentar obtener del caché
+            const cached = await this.cacheManager.get<PaginatedResult<Order>>(cacheKey);
+            if (cached) {
+                return cached;
+            }
+
             const skip = (page - 1) * limit;
             const filter = {
                 userId,
@@ -229,10 +240,15 @@ export class OrderService {
                 this.orderModel.countDocuments(filter),
             ]);
 
-            return {
+            const result: PaginatedResult<Order> = {
                 data,
                 pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
             };
+
+            // Guardar en caché por 30 segundos (órdenes cambian frecuentemente)
+            await this.cacheManager.set(cacheKey, result, 30);
+
+            return result;
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }

--- a/server/src/products/product.service.ts
+++ b/server/src/products/product.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { ConflictException, Inject, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Product, ProductDocument } from './schemas/product.schema';
 import { Model } from 'mongoose';
@@ -8,12 +8,15 @@ import { AddProductDto } from './dto/add-product.dto';
 import { ChangeStockDto } from './dto/change-stock.dto';
 import { generateISBN, estimatePageCount, assignDefaultAuthor, assignDefaultPublisher, generatePublicationYear } from './utils/migration.utils';
 import { PaginatedResult, PaginationDto } from 'src/common/dto/pagination.dto';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 
 @Injectable()
 export class ProductService {
     constructor(
         @InjectModel(Product.name) private productModel: Model<ProductDocument>,
         private configService: ConfigService,
+        @Inject(CACHE_MANAGER) private cacheManager: Cache,
     ) {
         // Configure cloudinary
         cloudinary.config({
@@ -82,6 +85,14 @@ export class ProductService {
     async listProducts(pagination: PaginationDto = {}): Promise<PaginatedResult<Product>> {
         try {
             const { page = 1, limit = 20 } = pagination;
+            const cacheKey = `products:list:${page}:${limit}`;
+
+            // Intentar obtener del caché
+            const cached = await this.cacheManager.get<PaginatedResult<Product>>(cacheKey);
+            if (cached) {
+                return cached;
+            }
+
             const skip = (page - 1) * limit;
 
             const [data, total] = await Promise.all([
@@ -89,7 +100,7 @@ export class ProductService {
                 this.productModel.countDocuments(),
             ]);
 
-            return {
+            const result: PaginatedResult<Product> = {
                 data,
                 pagination: {
                     page,
@@ -98,6 +109,11 @@ export class ProductService {
                     totalPages: Math.ceil(total / limit),
                 },
             };
+
+            // Guardar en caché por 2 minutos
+            await this.cacheManager.set(cacheKey, result, 120);
+
+            return result;
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }
@@ -109,8 +125,20 @@ export class ProductService {
      */
     async getSingleProduct(productId: string): Promise<Product> {
         try {
+            const cacheKey = `product:${productId}`;
+
+            // Intentar obtener del caché
+            const cached = await this.cacheManager.get<Product>(cacheKey);
+            if (cached) {
+                return cached;
+            }
+
             const product = await this.productModel.findById(productId);
             if (!product) throw new NotFoundException('Product not found');
+
+            // Guardar en caché por 5 minutos (producto individual)
+            await this.cacheManager.set(cacheKey, product.toObject(), 300);
+
             return product;
         } catch (error: any) {
             if (error instanceof NotFoundException) throw error;
@@ -164,10 +192,23 @@ export class ProductService {
      */
     async searchByISBN(isbn: string): Promise<{ found: boolean; product?: Product }> {
         try {
+            const cacheKey = `product:isbn:${isbn}`;
+
+            // Intentar obtener del caché
+            const cached = await this.cacheManager.get<{ found: boolean; product?: Product }>(cacheKey);
+            if (cached) {
+                return cached;
+            }
+
             const product = await this.productModel.findOne({ isbn }).lean().exec();
             const found = product !== null;
+            const result = { found, product: product ?? undefined };
+
+            // Guardar en caché por 10 minutos (ISBN es estable)
+            await this.cacheManager.set(cacheKey, result, 600);
+
             console.log(`[ProductService] ISBN search ${isbn}: ${found ? 'FOUND' : 'NOT FOUND'}`);
-            return { found, product: product ?? undefined };
+            return result;
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }
@@ -179,7 +220,6 @@ export class ProductService {
      */
     async search(query: string, pagination: PaginationDto = {}): Promise<PaginatedResult<Product>> {
         const { page = 1, limit = 20 } = pagination;
-        const skip = (page - 1) * limit;
         const cleanQuery = query.replace(/-/g, '');
         const isIsbn = /^\d{9}[\dX]$/.test(cleanQuery) || /^\d{13}$/.test(cleanQuery);
 
@@ -193,6 +233,16 @@ export class ProductService {
             };
         }
 
+        const cacheKey = `products:search:${query}:${page}:${limit}`;
+
+        // Intentar obtener del caché
+        const cached = await this.cacheManager.get<PaginatedResult<Product>>(cacheKey);
+        if (cached) {
+            return cached;
+        }
+
+        const skip = (page - 1) * limit;
+
         const filter = {
             $or: [
                 { name: { $regex: query, $options: 'i' } },
@@ -205,7 +255,7 @@ export class ProductService {
             this.productModel.countDocuments(filter),
         ]);
 
-        return {
+        const result: PaginatedResult<Product> = {
             data,
             pagination: {
                 page,
@@ -214,6 +264,11 @@ export class ProductService {
                 totalPages: Math.ceil(total / limit),
             },
         };
+
+        // Guardar en caché por 2 minutos
+        await this.cacheManager.set(cacheKey, result, 120);
+
+        return result;
     }
 
     /**
@@ -229,6 +284,10 @@ export class ProductService {
                 { new: true },
             );
             if (!product) throw new NotFoundException('Product not found');
+
+            // Invalidar caché del producto específico
+            await this.cacheManager.del(`product:${productId}`);
+
             return { message: 'Stock Updated' };
         } catch (error: any) {
             if (error instanceof NotFoundException) throw error;
@@ -559,6 +618,9 @@ export class ProductService {
 
             if (!updatedProduct) throw new NotFoundException('Product not found after update');
 
+            // Invalidar caché del producto
+            await this.cacheManager.del(`product:${productId}`);
+
             return {
                 message: `Translation for ${lang} updated successfully`,
                 product: updatedProduct,
@@ -598,6 +660,10 @@ export class ProductService {
                     await this.productModel.findByIdAndUpdate(translation.productId, {
                         translations: productTranslations,
                     });
+
+                    // Invalidar caché de cada producto actualizado
+                    await this.cacheManager.del(`product:${translation.productId}`);
+
                     updatedCount++;
                 }
             }

--- a/server/src/reservations/reservation.service.ts
+++ b/server/src/reservations/reservation.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 import { Reservation, ReservationDocument } from './schemas/reservation.schema';
@@ -6,6 +6,8 @@ import { Loan, LoanDocument } from 'src/loans/schemas/loan.schema';
 import { ProductService } from 'src/products/product.service';
 import { PredictionClient } from 'src/prediction/prediction-client.service';
 import { PaginatedResult, PaginationDto } from 'src/common/dto/pagination.dto';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 
 /**
  * Interfaz para los datos de historial de préstamos del usuario.
@@ -14,15 +16,6 @@ interface UserLoanHistory {
     userId: string;
     puntualidadPromedio: number; // 0 a 1 (1 = siempre a tiempo)
     tasaDevTardias: number;      // 0 a 1 (1 = todas las devoluciones fueron tardías)
-}
-
-/**
- * Interfaz para una entrada del caché de scoring de usuario.
- */
-interface ScoreCacheEntry {
-    puntualidadPromedio: number;
-    tasaDevTardias: number;
-    expiresAt: Date;
 }
 
 /**
@@ -49,15 +42,11 @@ interface ScoredReservation {
 export class ReservationService {
     private readonly logger = new Logger(ReservationService.name);
 
-    // Cache de historial de usuarios: userId -> ScoreCacheEntry (con TTL de 5 min)
-    private scoreCache = new Map<string, ScoreCacheEntry>();
-
     // Pesos configurables (default: 0.4, 0.3, 0.2, 0.1)
     private readonly ALPHA: number;
     private readonly BETA: number;
     private readonly GAMMA: number;
     private readonly DELTA: number;
-    private readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutos
 
     constructor(
         @InjectModel(Reservation.name)
@@ -66,6 +55,7 @@ export class ReservationService {
         private loanModel: Model<LoanDocument>,
         private productService: ProductService,
         private predictionClient: PredictionClient,
+        @Inject(CACHE_MANAGER) private cacheManager: Cache,
     ) {
         this.ALPHA = parseFloat(process.env.RESERVATION_SCORE_ALPHA || '0.4');
         this.BETA = parseFloat(process.env.RESERVATION_SCORE_BETA || '0.3');
@@ -420,9 +410,6 @@ export class ReservationService {
             // 8. Reordenar la cola restante
             await this.reorderQueue(productId);
 
-            // 9. Limpiar caché expirada
-            this.cleanExpiredCache();
-
             this.logger.log(
                 `Reservation fulfilled: ${winner.reservation._id} | ` +
                 `userId: ${(winner.reservation.userId as any)._id} | ` +
@@ -448,12 +435,14 @@ export class ReservationService {
     ): Promise<Map<string, UserLoanHistory>> {
         const resultMap = new Map<string, UserLoanHistory>();
         const uncachedUserIds: string[] = [];
-        const now = new Date();
 
         // 1. Separar cache hits de cache misses
         for (const userId of userIds) {
-            const cached = this.scoreCache.get(userId);
-            if (cached && cached.expiresAt > now) {
+
+            // 2. Verificar si el usuario está en caché
+            const cacheKey = `reservation:score:${userId}`;
+            const cached = await this.cacheManager.get<{ puntualidadPromedio: number; tasaDevTardias: number }>(cacheKey);
+            if (cached) {
                 // Cache hit: usar valor cacheado
                 resultMap.set(userId, {
                     userId,
@@ -477,11 +466,11 @@ export class ReservationService {
 
             // 3. Almacenar en caché y agregar al mapa de resultados
             for (const [userId, history] of freshHistory) {
-                this.scoreCache.set(userId, {
+                const cacheKey = `reservation:score:${userId}`;
+                await this.cacheManager.set(cacheKey, {
                     puntualidadPromedio: history.puntualidadPromedio,
                     tasaDevTardias: history.tasaDevTardias,
-                    expiresAt: new Date(now.getTime() + this.CACHE_TTL_MS),
-                });
+                }, 300); // TTL 5 minutos
 
                 resultMap.set(userId, history);
             }
@@ -498,11 +487,11 @@ export class ReservationService {
                 resultMap.set(userId, neutro);
 
                 // También cachear el neutro para evitar repetir la query
-                this.scoreCache.set(userId, {
+                const cacheKey = `reservation:score:${userId}`;
+                await this.cacheManager.set(cacheKey, {
                     puntualidadPromedio: 0,
                     tasaDevTardias: 0,
-                    expiresAt: new Date(now.getTime() + this.CACHE_TTL_MS),
-                });
+                }, 300);
             }
         }
 
@@ -820,23 +809,6 @@ export class ReservationService {
                 }
             }
             return resultMap;
-        }
-    }
-
-    /**
-     * Limpia entradas expiradas del caché en memoria.
-     */
-    private cleanExpiredCache(): void {
-        const now = new Date();
-        let cleaned = 0;
-        for (const [key, entry] of this.scoreCache.entries()) {
-            if (entry.expiresAt <= now) {
-                this.scoreCache.delete(key);
-                cleaned++;
-            }
-        }
-        if (cleaned > 0) {
-            this.logger.debug(`Cache cleaned: ${cleaned} expired entries removed`);
         }
     }
 }

--- a/server/src/shelves/shelf.service.ts
+++ b/server/src/shelves/shelf.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { ConfigService } from '@nestjs/config';
 import { Shelf, ShelfDocument } from './schemas/shelf.schema';
@@ -7,6 +7,8 @@ import { Product, ProductDocument } from 'src/products/schemas/product.schema';
 import { Loan, LoanDocument } from 'src/loans/schemas/loan.schema';
 import { CreateShelfDto } from './dtos/create-shelf.dto';
 import { PaginatedResult, PaginationDto } from 'src/common/dto/pagination.dto';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 
 @Injectable()
 export class ShelfService {
@@ -21,6 +23,7 @@ export class ShelfService {
         @InjectModel(Product.name) private productModel: Model<ProductDocument>,
         @InjectModel(Loan.name) private loanModel: Model<LoanDocument>,
         private readonly configService: ConfigService,
+        @Inject(CACHE_MANAGER) private cacheManager: Cache,
     ) {
         this.W_ROTATION = this.configService.get<number>('SHELF_ASSIGN_W_ROTATION', 0.35);
         this.W_DIVERSITY = this.configService.get<number>('SHELF_ASSIGN_W_DIVERSITY', 0.30);
@@ -47,6 +50,9 @@ export class ShelfService {
                 maxWeight: createShelfDto.maxWeight || 8,
             });
 
+            // Invalidar caché de categorías totales y listados
+            await this.cacheManager.del('shelf:categories:total');
+
             console.log(`[ShelfService] Shelf created: ${shelf.code}`);
             return shelf;
         } catch (error: any) {
@@ -63,6 +69,14 @@ export class ShelfService {
     async listShelves(pagination: PaginationDto = {}): Promise<PaginatedResult<Shelf>> {
         try {
             const { page = 1, limit = 20 } = pagination;
+            const cacheKey = `shelves:list:${page}:${limit}`;
+
+            // Intentar obtener del caché
+            const cached = await this.cacheManager.get<PaginatedResult<Shelf>>(cacheKey);
+            if (cached) {
+                return cached;
+            }
+
             const skip = (page - 1) * limit;
 
             const [data, total] = await Promise.all([
@@ -77,10 +91,15 @@ export class ShelfService {
                 this.shelfModel.countDocuments(),
             ]);
 
-            return {
+            const result: PaginatedResult<Shelf> = {
                 data,
                 pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
             };
+
+            // Guardar en caché por 5 minutos
+            await this.cacheManager.set(cacheKey, result, 300);
+
+            return result;
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }
@@ -360,8 +379,21 @@ export class ShelfService {
      * Obtiene el total de categorías únicas en el sistema.
      */
     private async getTotalCategories(): Promise<number> {
+        const cacheKey = 'shelf:categories:total';
+
+        // Intentar obtener del caché
+        const cached = await this.cacheManager.get<number>(cacheKey);
+        if (cached !== undefined && cached !== null) {
+            return cached;
+        }
+
         const categories = await this.productModel.distinct('category');
-        return categories.length;
+        const count = categories.length;
+
+        // Guardar en caché por 15 minutos (cambian rara vez)
+        await this.cacheManager.set(cacheKey, count, 900);
+
+        return count;
     }
 
     /**
@@ -421,6 +453,9 @@ export class ShelfService {
         // Actualizar libro
         book.shelfLocation = new Types.ObjectId(shelfId);
         await book.save();
+
+        // Invalidar caché de estantes
+        await this.cacheManager.del('shelf:categories:total');
 
         console.log(`[ShelfService] Book ${book._id} assigned to shelf ${shelf.code}`);
 
@@ -935,6 +970,9 @@ export class ShelfService {
             // Actualizar libro
             book.shelfLocation = null as any;
             await book.save();
+
+            // Invalidar caché
+            await this.cacheManager.del('shelf:categories:total');
 
             console.log(`[ShelfService] Book ${bookId} removed from shelf ${shelf.code}`);
 

--- a/server/src/users/user.service.ts
+++ b/server/src/users/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ConflictException, InternalServerErrorException, UnauthorizedException, NotFoundException, BadRequestException } from '@nestjs/common';
+import { ConflictException, Inject, Injectable, InternalServerErrorException, UnauthorizedException, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { User, UserDocument } from './schemas/user.schema';
@@ -15,6 +15,8 @@ import { UpdateProfileDto } from './dto/update-profile.dto';
 import { EmailService } from 'src/email/email.service';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 
 @Injectable()
 export class UserService {
@@ -22,6 +24,7 @@ export class UserService {
         @InjectModel(User.name) private userModel: Model<UserDocument>,
         private configService: ConfigService,
         private emailService: EmailService,
+        @Inject(CACHE_MANAGER) private cacheManager: Cache,
     ) {
         // Configure cloudinary
         cloudinary.config({
@@ -58,7 +61,7 @@ export class UserService {
                 token,
                 user: { email: user.email, name: user.name, profileImage: user.profileImage ?? '' },
             };
-        } catch (error) {
+        } catch (error: any) {
             if (error instanceof ConflictException) throw error;
             throw new InternalServerErrorException(error.message);
         }
@@ -120,7 +123,7 @@ export class UserService {
                 expiresIn,
                 isAdmin,
             };
-        } catch (error) {
+        } catch (error: any) {
             if (error instanceof UnauthorizedException) throw error;
             throw new InternalServerErrorException(error.message);
         }
@@ -139,7 +142,7 @@ export class UserService {
                 user: { email: user.email, name: user.name, profileImage: user.profileImage ?? '' },
                 isAdmin,
             };
-        } catch (error) {
+        } catch (error: any) {
             if (error instanceof NotFoundException) throw error;
             throw new InternalServerErrorException(error.message);
         }
@@ -156,19 +159,32 @@ export class UserService {
                 console.log(`[UserService] User ${user.email} logged out at ${new Date().toISOString()}`);
             }
             return { message: 'Successfully logged out' };
-        } catch (error) {
+        } catch (error: any) {
             throw new InternalServerErrorException('Error during logout');
         }
     }
 
     async getUserById(userId: string): Promise<UserResponseDto> {
         try {
+            const cacheKey = `user:${userId}`;
+
+            // Intentar obtener del caché
+            const cached = await this.cacheManager.get<UserResponseDto>(cacheKey);
+            if (cached) {
+                return cached;
+            }
+
             const user = await this.userModel.findById(userId).select('-password');
 
             if (!user) throw new NotFoundException('User not found');
 
-            return { email: user.email, name: user.name, profileImage: user.profileImage ?? '' };
-        } catch (error) {
+            const result: UserResponseDto = { email: user.email, name: user.name, profileImage: user.profileImage ?? '' };
+
+            // Guardar en caché por 60 segundos
+            await this.cacheManager.set(cacheKey, result, 60);
+
+            return result;
+        } catch (error: any) {
             if (error instanceof NotFoundException) throw error;
             throw new InternalServerErrorException(error.message);
         }
@@ -176,10 +192,18 @@ export class UserService {
 
     async getProfile(userId: string): Promise<{ user: any }> {
         try {
+            const cacheKey = `user:profile:${userId}`;
+
+            // Intentar obtener del caché
+            const cached = await this.cacheManager.get<{ user: any }>(cacheKey);
+            if (cached) {
+                return cached;
+            }
+
             const user = await this.userModel.findById(userId).select('-password');
             if (!user) throw new NotFoundException('User not found');
 
-            return {
+            const result = {
                 user: {
                     name: user.name,
                     email: user.email,
@@ -187,7 +211,12 @@ export class UserService {
                     profileImage: user.profileImage ?? '',
                 },
             };
-        } catch (error) {
+
+            // Guardar en caché por 60 segundos
+            await this.cacheManager.set(cacheKey, result, 60);
+
+            return result;
+        } catch (error: any) {
             if (error instanceof NotFoundException) throw error;
             throw new InternalServerErrorException(error.message);
         }
@@ -229,6 +258,10 @@ export class UserService {
 
             await user.save();
 
+            // Invalidar caché del usuario
+            await this.cacheManager.del(`user:${userId}`);
+            await this.cacheManager.del(`user:profile:${userId}`);
+
             return {
                 message: 'Profile updated successfully',
                 user: {
@@ -238,7 +271,7 @@ export class UserService {
                     profileImage: user.profileImage,
                 },
             };
-        } catch (error) {
+        } catch (error: any) {
             if (
                 error instanceof NotFoundException ||
                 error instanceof ConflictException ||
@@ -288,7 +321,7 @@ export class UserService {
             return {
                 message: 'If this email exists, a password reset link has been sent',
             };
-        } catch (error) {
+        } catch (error: any) {
             console.error('[UserService] Error in forgotPassword:', error);
             throw new InternalServerErrorException('Error processing password reset request');
         }
@@ -314,7 +347,7 @@ export class UserService {
                     token,
                     this.configService.getOrThrow<string>('JWT_SECRET'),
                 );
-            } catch (error) {
+            } catch (error: any) {
                 if (error.name === 'TokenExpiredError') {
                     throw new UnauthorizedException('Reset link has expired. Please request a new one');
                 }
@@ -351,7 +384,7 @@ export class UserService {
             return {
                 message: 'Password has been reset successfully. You can now log in with your new password',
             };
-        } catch (error) {
+        } catch (error: any) {
             if (
                 error instanceof BadRequestException ||
                 error instanceof UnauthorizedException ||
@@ -376,8 +409,13 @@ export class UserService {
             cartData[itemId] = (cartData[itemId] ?? 0) + 1;
 
             await this.userModel.findByIdAndUpdate(userId, { cartData });
+
+            // Invalidar caché del usuario
+            await this.cacheManager.del(`user:${userId}`);
+            await this.cacheManager.del(`user:profile:${userId}`);
+
             return { message: 'Added to Cart' };
-        } catch (error) {
+        } catch (error: any) {
             if (error instanceof NotFoundException) throw error;
             throw new InternalServerErrorException(error.message);
         }
@@ -401,8 +439,13 @@ export class UserService {
             }
 
             await this.userModel.findByIdAndUpdate(userId, { cartData });
+
+            // Invalidar caché del usuario
+            await this.cacheManager.del(`user:${userId}`);
+            await this.cacheManager.del(`user:profile:${userId}`);
+
             return { message: 'Cart Updated' };
-        } catch (error) {
+        } catch (error: any) {
             if (error instanceof NotFoundException) throw error;
             throw new InternalServerErrorException(error.message);
         }


### PR DESCRIPTION
…ager

- Add CacheModule with Redis store (cache-manager-ioredis-yet) and in-memory fallback when REDIS_HOST is not configured
- Migrate ReservationService scoreCache from in-memory Map to Redis, surviving restarts and shared across instances
- Add cache to ProductService: getSingleProduct (5min), listProducts (2min), search (2min), searchByISBN (10min)
- Add cache to UserService: getUserById and getProfile (60s)
- Add cache to LoanService: getUserLoanStats (5min)
- Add cache to ShelfService: listShelves (5min), getTotalCategories (15min)
- Add cache to OrderService: userOrders (30s)
- Add cache invalidation on all write operations across services
- Add Redis service to docker-compose.yaml for local development
- Add REDIS_HOST and REDIS_PORT to .env.example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis-backed caching to improve response times across products, orders, loans, shelves, reservations, and user profiles.
  * Added automatic cache refresh and invalidation when products, loans, shelves, profiles, or carts change.
  * Added configuration options for Redis connectivity, with in-memory caching available when Redis is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->