### PR TITLE
feat(i18n): implement product translation system (en/es)

### DIFF
--- a/client/src/components/admin/TranslationModal.jsx
+++ b/client/src/components/admin/TranslationModal.jsx
@@ -2,23 +2,22 @@ import { useState, useContext, useEffect } from 'react';
 import { ShopContext } from '../../context/ShopContext';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
-import { MdClose, MdTranslate, MdSave } from 'react-icons/md';
+import { MdClose, MdTranslate, MdSave, MdAutoFixHigh } from 'react-icons/md';
 
 const TranslationModal = ({ product, isOpen, onClose, onSave }) => {
     const { axios } = useContext(ShopContext);
     const { t } = useTranslation();
-    
+
     const [translations, setTranslations] = useState({
-        es: {
-            name: '',
-            description: '',
-            category: ''
-        }
+        es: { name: '', description: '', category: '' },
+        en: { name: '', description: '', category: '' },
     });
+    const [activeTab, setActiveTab] = useState('es');
     const [loading, setLoading] = useState(false);
+    const [loadingAuto, setLoadingAuto] = useState(false);
     const [loadingTranslations, setLoadingTranslations] = useState(false);
 
-    // Cargar traducciones existentes cuando se abre el modal
+    // Load existing translations when modal opens
     useEffect(() => {
         if (isOpen && product?._id) {
             loadExistingTranslations();
@@ -29,14 +28,23 @@ const TranslationModal = ({ product, isOpen, onClose, onSave }) => {
         try {
             setLoadingTranslations(true);
             const { data } = await axios.get(`/api/product/translations/${product._id}`);
-            
+
             if (data.success && data.translations) {
                 setTranslations({
                     es: {
                         name: data.translations.es?.name || '',
                         description: data.translations.es?.description || '',
-                        category: data.translations.es?.category || ''
-                    }
+                        category: data.translations.es?.category || '',
+                        translatedAt: data.translations.es?.translatedAt,
+                        translatedBy: data.translations.es?.translatedBy,
+                    },
+                    en: {
+                        name: data.translations.en?.name || '',
+                        description: data.translations.en?.description || '',
+                        category: data.translations.en?.category || '',
+                        translatedAt: data.translations.en?.translatedAt,
+                        translatedBy: data.translations.en?.translatedBy,
+                    },
                 });
             }
         } catch (error) {
@@ -51,35 +59,70 @@ const TranslationModal = ({ product, isOpen, onClose, onSave }) => {
             ...prev,
             [lang]: {
                 ...prev[lang],
-                [field]: value
-            }
+                [field]: value,
+            },
         }));
     };
 
     const handleSave = async () => {
         try {
             setLoading(true);
-            
+
             const { data } = await axios.post(
-                `/api/product/translation/${product._id}/es`,
-                translations.es
+                `/api/product/translation/${product._id}/${activeTab}`,
+                {
+                    name: translations[activeTab].name,
+                    description: translations[activeTab].description,
+                    category: translations[activeTab].category,
+                }
             );
 
             if (data.success) {
-                toast.success('Traducción guardada exitosamente');
+                toast.success('Translation saved successfully');
                 onSave && onSave();
                 onClose();
             } else {
-                toast.error(data.message || 'Error al guardar traducción');
+                toast.error(data.message || 'Error saving translation');
             }
         } catch (error) {
-            toast.error(error.response?.data?.message || 'Error al guardar traducción');
+            toast.error(error.response?.data?.message || 'Error saving translation');
         } finally {
             setLoading(false);
         }
     };
 
+    const handleAutoTranslate = async () => {
+        try {
+            setLoadingAuto(true);
+
+            const { data } = await axios.post(
+                `/api/product/translate/${product._id}/${activeTab}`
+            );
+
+            if (data.success) {
+                toast.success(`Product translated to ${activeTab === 'es' ? 'Spanish' : 'English'}`);
+                // Reload translations to show the new ones
+                await loadExistingTranslations();
+                onSave && onSave();
+            } else {
+                toast.error(data.message || 'Auto-translation failed');
+            }
+        } catch (error) {
+            toast.error(error.response?.data?.message || 'Auto-translation failed');
+        } finally {
+            setLoadingAuto(false);
+        }
+    };
+
     if (!isOpen) return null;
+
+    const otherLang = activeTab === 'es' ? 'en' : 'es';
+    const originalLang = 'en'; // Products are originally in English
+    const originalData = {
+        name: product?.name,
+        category: product?.category,
+        description: product?.description,
+    };
 
     return (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
@@ -89,7 +132,7 @@ const TranslationModal = ({ product, isOpen, onClose, onSave }) => {
                     <div className="flex items-center gap-2">
                         <MdTranslate className="text-2xl text-secondary" />
                         <h2 className="text-lg font-semibold">
-                            {t('common.edit')} - Traducciones
+                            {t('common.edit')} - {t('productTranslations.title')}
                         </h2>
                     </div>
                     <button
@@ -97,6 +140,28 @@ const TranslationModal = ({ product, isOpen, onClose, onSave }) => {
                         className="p-2 hover:bg-white/50 rounded-full transition-colors"
                     >
                         <MdClose className="text-xl" />
+                    </button>
+                </div>
+
+                {/* Language Tabs */}
+                <div className="flex border-b">
+                    <button
+                        onClick={() => setActiveTab('es')}
+                        className={`flex-1 py-3 text-center font-medium transition-colors ${activeTab === 'es'
+                                ? 'text-secondary border-b-2 border-secondary bg-secondary/5'
+                                : 'text-gray-500 hover:text-gray-700'
+                            }`}
+                    >
+                        🇪🇸 Español
+                    </button>
+                    <button
+                        onClick={() => setActiveTab('en')}
+                        className={`flex-1 py-3 text-center font-medium transition-colors ${activeTab === 'en'
+                                ? 'text-secondary border-b-2 border-secondary bg-secondary/5'
+                                : 'text-gray-500 hover:text-gray-700'
+                            }`}
+                    >
+                        🇺🇸 English
                     </button>
                 </div>
 
@@ -112,56 +177,89 @@ const TranslationModal = ({ product, isOpen, onClose, onSave }) => {
                             {/* Original (English) */}
                             <div className="mb-6 p-4 bg-gray-50 rounded-lg">
                                 <h3 className="font-medium mb-3 flex items-center gap-2">
-                                    <span className="text-lg">🇺🇸</span> Original (English)
+                                    <span className="text-lg">🇺🇸</span> Original ({originalLang})
                                 </h3>
                                 <div className="space-y-2 text-sm text-gray-600">
-                                    <p><strong>Name:</strong> {product?.name}</p>
-                                    <p><strong>Category:</strong> {product?.category}</p>
-                                    <p><strong>Description:</strong> {product?.description?.substring(0, 150)}...</p>
+                                    <p><strong>Name:</strong> {originalData.name}</p>
+                                    <p><strong>Category:</strong> {originalData.category}</p>
+                                    <p><strong>Description:</strong> {originalData.description?.substring(0, 150)}...</p>
                                 </div>
                             </div>
 
-                            {/* Spanish Translation */}
+                            {/* Translation metadata */}
+                            {translations[activeTab]?.translatedAt && (
+                                <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-sm">
+                                    <span className="text-green-700">
+                                        ✅ {t('productTranslations.translated')} •
+                                        {t('productTranslations.translatedBy')}: {translations[activeTab].translatedBy} •
+                                        {new Date(translations[activeTab].translatedAt).toLocaleDateString()}
+                                    </span>
+                                </div>
+                            )}
+
+                            {/* Auto-translate button */}
+                            <div className="mb-4">
+                                <button
+                                    onClick={handleAutoTranslate}
+                                    disabled={loadingAuto}
+                                    className="flex items-center gap-2 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors disabled:opacity-50"
+                                >
+                                    {loadingAuto ? (
+                                        <>
+                                            <div className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full"></div>
+                                            Translating...
+                                        </>
+                                    ) : (
+                                        <>
+                                            <MdAutoFixHigh />
+                                            {t('productTranslations.autoTranslate')}
+                                        </>
+                                    )}
+                                </button>
+                            </div>
+
+                            {/* Translation fields */}
                             <div className="p-4 border-2 border-secondary/20 rounded-lg">
                                 <h3 className="font-medium mb-4 flex items-center gap-2">
-                                    <span className="text-lg">🇪🇸</span> Español
+                                    <span className="text-lg">{activeTab === 'es' ? '🇪🇸' : '🇺🇸'}</span>
+                                    {activeTab === 'es' ? 'Español' : 'English'}
                                 </h3>
-                                
+
                                 <div className="space-y-4">
                                     <div>
                                         <label className="block text-sm font-medium mb-1">
-                                            Nombre del Libro
+                                            {t('productTranslations.bookName')}
                                         </label>
                                         <input
                                             type="text"
-                                            value={translations.es.name}
-                                            onChange={(e) => handleChange('es', 'name', e.target.value)}
-                                            placeholder={product?.name}
+                                            value={translations[activeTab].name}
+                                            onChange={(e) => handleChange(activeTab, 'name', e.target.value)}
+                                            placeholder={originalData.name}
                                             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-secondary focus:border-transparent"
                                         />
                                     </div>
 
                                     <div>
                                         <label className="block text-sm font-medium mb-1">
-                                            Categoría
+                                            {t('productTranslations.category')}
                                         </label>
                                         <input
                                             type="text"
-                                            value={translations.es.category}
-                                            onChange={(e) => handleChange('es', 'category', e.target.value)}
-                                            placeholder={product?.category}
+                                            value={translations[activeTab].category}
+                                            onChange={(e) => handleChange(activeTab, 'category', e.target.value)}
+                                            placeholder={originalData.category}
                                             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-secondary focus:border-transparent"
                                         />
                                     </div>
 
                                     <div>
                                         <label className="block text-sm font-medium mb-1">
-                                            Descripción
+                                            {t('productTranslations.description')}
                                         </label>
                                         <textarea
-                                            value={translations.es.description}
-                                            onChange={(e) => handleChange('es', 'description', e.target.value)}
-                                            placeholder={product?.description}
+                                            value={translations[activeTab].description}
+                                            onChange={(e) => handleChange(activeTab, 'description', e.target.value)}
+                                            placeholder={originalData.description}
                                             rows={5}
                                             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-secondary focus:border-transparent resize-none"
                                         />
@@ -188,7 +286,7 @@ const TranslationModal = ({ product, isOpen, onClose, onSave }) => {
                         {loading ? (
                             <>
                                 <div className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full"></div>
-                                Guardando...
+                                {t('productTranslations.saving')}
                             </>
                         ) : (
                             <>

--- a/client/src/components/admin/TranslationModal.jsx
+++ b/client/src/components/admin/TranslationModal.jsx
@@ -207,7 +207,7 @@ const TranslationModal = ({ product, isOpen, onClose, onSave }) => {
                                     {loadingAuto ? (
                                         <>
                                             <div className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full"></div>
-                                            Translating...
+                                            {t('productTranslations.translating')}
                                         </>
                                     ) : (
                                         <>

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -623,5 +623,24 @@
             "tailRecursion": "Tail Recursion:",
             "tailRecursionDesc": "Calculates average weight using optimized tail recursion (1 page = 0.005 Kg)."
         }
+    },
+    "productTranslations": {
+        "title": "Product Translations",
+        "translate": "Translate",
+        "translateAll": "Translate All",
+        "translated": "Translated",
+        "pending": "Pending Translation",
+        "autoTranslate": "Auto-translate",
+        "autoTranslateOnSave": "Auto-translate on save",
+        "translationProgress": "Translation Progress",
+        "productsTranslated": "{{count}} of {{total}} products translated",
+        "selectLanguage": "Select language",
+        "originalLanguage": "Original Language",
+        "lastUpdated": "Last Updated",
+        "translatedBy": "Translated by",
+        "bookName": "Book Name",
+        "category": "Category",
+        "description": "Description",
+        "saving": "Saving..."
     }
 }

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -623,5 +623,24 @@
             "tailRecursion": "Recursión de Cola:",
             "tailRecursionDesc": "Calcula el peso promedio usando recursión de cola optimizada (1 página = 0.005 Kg)."
         }
+    },
+    "productTranslations": {
+        "title": "Traducciones de Productos",
+        "translate": "Traducir",
+        "translateAll": "Traducir Todos",
+        "translated": "Traducido",
+        "pending": "Pendiente de Traducción",
+        "autoTranslate": "Traducir automáticamente",
+        "autoTranslateOnSave": "Traducir automáticamente al guardar",
+        "translationProgress": "Progreso de Traducción",
+        "productsTranslated": "{{count}} de {{total}} productos traducidos",
+        "selectLanguage": "Seleccionar idioma",
+        "originalLanguage": "Idioma Original",
+        "lastUpdated": "Última Actualización",
+        "translatedBy": "Traducido por",
+        "bookName": "Nombre del Libro",
+        "category": "Categoría",
+        "description": "Descripción",
+        "saving": "Guardando..."
     }
 }

--- a/client/src/pages/admin/AddProduct.jsx
+++ b/client/src/pages/admin/AddProduct.jsx
@@ -12,18 +12,20 @@ const AddProduct = () => {
     const [offerPrice, setOfferPrice] = useState("10")
     const [category, setCategory] = useState("Academic")
     const [popular, setPopular] = useState(false)
+    const [autoTranslate, setAutoTranslate] = useState(true)
 
     const onSubmitHandler = (event) => {
         event.preventDefault();
         try {
             const formData = new FormData();
-            
+
             formData.append('name', name);
             formData.append('description', description);
             formData.append('category', category);
             formData.append('price', price);
             formData.append('offerPrice', offerPrice);
             formData.append('popular', popular.toString());
+            formData.append('autoTranslate', autoTranslate.toString());
 
             for (let i = 0; i < files.length; i++) {
                 formData.append("images", files[i]);
@@ -161,6 +163,20 @@ const AddProduct = () => {
                         className='cursor-pointer'
                     >
                         Add to Popular
+                    </label>
+                </div>
+                <div className='flexStart gap-2 my-2'>
+                    <input
+                        onChange={() => setAutoTranslate(prev => !prev)}
+                        checked={autoTranslate}
+                        type="checkbox"
+                        id='autoTranslate'
+                    />
+                    <label
+                        htmlFor="autoTranslate"
+                        className='cursor-pointer'
+                    >
+                        Traducir automáticamente al guardar
                     </label>
                 </div>
                 <button

--- a/client/src/pages/admin/AddProduct.jsx
+++ b/client/src/pages/admin/AddProduct.jsx
@@ -2,6 +2,7 @@ import { useContext, useState } from 'react'
 import upload_icon from '../../assets/upload_icon.png'
 import { ShopContext } from '../../context/ShopContext'
 import toast from 'react-hot-toast'
+import { useTranslation } from 'react-i18next'
 
 const AddProduct = () => {
     const { axios } = useContext(ShopContext)
@@ -13,6 +14,7 @@ const AddProduct = () => {
     const [category, setCategory] = useState("Academic")
     const [popular, setPopular] = useState(false)
     const [autoTranslate, setAutoTranslate] = useState(true)
+    const { t } = useTranslation()
 
     const onSubmitHandler = (event) => {
         event.preventDefault();
@@ -176,7 +178,7 @@ const AddProduct = () => {
                         htmlFor="autoTranslate"
                         className='cursor-pointer'
                     >
-                        Traducir automáticamente al guardar
+                        {t('productTranslations.autoTranslateOnSave')}
                     </label>
                 </div>
                 <button

--- a/client/src/pages/admin/ProductList.jsx
+++ b/client/src/pages/admin/ProductList.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react'
+import { useContext, useState, useEffect } from 'react'
 import { ShopContext } from '../../context/ShopContext'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
@@ -11,7 +11,23 @@ const ProductList = () => {
     const { t } = useTranslation()
     const [selectedProduct, setSelectedProduct] = useState(null)
     const [showTranslationModal, setShowTranslationModal] = useState(false)
+    const [translationStats, setTranslationStats] = useState(null)
     
+    const fetchTranslationStats = async () => {
+        try {
+            const { data } = await axios.get('/api/product/translation-stats')
+            if (data.success) {
+                setTranslationStats(data.stats)
+            }
+        } catch (error) {
+            console.error('Error loading translation stats:', error)
+        }
+    }
+
+    useEffect(() => {
+        fetchTranslationStats()
+    }, [])
+
     const toggleStock = async (productId, inStock) => {
         try {
             const { data } = await axios.post('/api/product/stock', { productId, inStock })
@@ -31,9 +47,63 @@ const ProductList = () => {
         setShowTranslationModal(true)
     }
 
+    const handleTranslateAll = async (toLanguage) => {
+        try {
+            const productIds = books.map(book => book._id)
+            const { data } = await axios.post('/api/product/translate-batch', {
+                productIds,
+                toLanguage,
+            })
+            if (data.success) {
+                toast.success(data.message)
+                fetchBooks()
+                fetchTranslationStats()
+            } else {
+                toast.error(data.message)
+            }
+        } catch (error) {
+            toast.error(error.response?.data?.message || 'Error translating products')
+        }
+    }
+
+    const hasTranslation = (book, lang) => {
+        return book.translations && book.translations[lang] && book.translations[lang].name
+    }
+
     return (
         <div className='px-2 sm:px-6 py-12 mt-2 h-[97vh] bg-primary overflow-y-scroll lg:w-4/5 rounded-xl'>
             <div className='flex flex-col gap-2'>
+                {/* Translation Stats Bar */}
+                {translationStats && (
+                    <div className='flex items-center justify-between p-3 bg-white rounded-lg mb-2'>
+                        <div className='flex items-center gap-4 text-sm'>
+                            <span className='font-medium'>
+                                {t('productTranslations.translationProgress')}:
+                            </span>
+                            <span className='text-green-600'>
+                                🇪🇸 {translationStats.translatedEs}/{translationStats.total} {t('productTranslations.translated')}
+                            </span>
+                            <span className='text-blue-600'>
+                                🇺🇸 {translationStats.translatedEn}/{translationStats.total} {t('productTranslations.translated')}
+                            </span>
+                        </div>
+                        <div className='flex gap-2'>
+                            <button
+                                onClick={() => handleTranslateAll('es')}
+                                className='px-3 py-1 text-xs bg-secondary text-white rounded hover:bg-secondary/90 transition-colors'
+                            >
+                                {t('productTranslations.translateAll')} → ES
+                            </button>
+                            <button
+                                onClick={() => handleTranslateAll('en')}
+                                className='px-3 py-1 text-xs bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors'
+                            >
+                                {t('productTranslations.translateAll')} → EN
+                            </button>
+                        </div>
+                    </div>
+                )}
+
                 <div className='grid grid-cols-[1fr_3fr_1fr_1fr_1fr_0.5fr] items-center py-1 px-2 bg-white bold-14 sm:bold-15 mb-1 rounded'>
                     <h5>{t('product.category') === 'Category' ? 'Image' : 'Imagen'}</h5>
                     <h5>{t('profile.name')}</h5>
@@ -42,27 +112,37 @@ const ProductList = () => {
                     <h5>{t('product.inStock')}</h5>
                     <h5><MdTranslate /></h5>
                 </div>
-                { /* LISTA DE PRODUCTOS */ }
+                { /* LISTA DE PRODUCTOS */}
                 {books.map((book) => (
                     <div
                         key={book._id}
                         className='grid grid-cols-[1fr_3fr_1fr_1fr_1fr_0.5fr] items-center gap-2 p-2 bg-white rounded-lg'
                     >
-                        <img 
-                            src={book.images[0]} 
-                            alt={book.name} 
+                        <img
+                            src={book.images[0]}
+                            alt={book.name}
                             className='w-12 bg-primary rounded'
                         />
-                        <h5 className="text-sm font-semibold">{book.name}</h5>
+                        <div className="flex flex-col">
+                            <h5 className="text-sm font-semibold">{book.name}</h5>
+                            <div className="flex gap-1 mt-1">
+                                <span className={`text-[10px] px-1.5 py-0.5 rounded ${hasTranslation(book, 'es') ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-400'}`}>
+                                    ES
+                                </span>
+                                <span className={`text-[10px] px-1.5 py-0.5 rounded ${hasTranslation(book, 'en') ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-400'}`}>
+                                    EN
+                                </span>
+                            </div>
+                        </div>
                         <p className='text-sm font-semibold'>{book.category}</p>
                         <div className='text-sm font-semibold'>{currency}{book.offerPrice}</div>
                         <div>
                             <label className="relative inline-flex items-center cursor-pointer text-gray-900 gap-3">
-                                <input 
-                                    onClick={()=>toggleStock(book._id, !book.inStock)}
-                                    type="checkbox" 
+                                <input
+                                    onClick={() => toggleStock(book._id, !book.inStock)}
+                                    type="checkbox"
                                     className="sr-only peer"
-                                    defaultChecked={book.inStock} 
+                                    defaultChecked={book.inStock}
                                 />
                                 <div className='w-10 h-6 bg-slate-300 rounded-full peer peer-checked:bg-secondary transition-colors duration-200' />
                                 <span className='absolute left-1 top-1 w-4 h-4 bg-white rounded-full transition-transform duration-200 ease-in-out peer-checked:translate-x-4' />
@@ -71,7 +151,7 @@ const ProductList = () => {
                         <button
                             onClick={() => openTranslationModal(book)}
                             className='p-2 hover:bg-primary rounded-lg transition-colors'
-                            title='Traducir'
+                            title={t('productTranslations.translate')}
                         >
                             <MdTranslate className='text-lg text-secondary' />
                         </button>
@@ -84,7 +164,7 @@ const ProductList = () => {
                 product={selectedProduct}
                 isOpen={showTranslationModal}
                 onClose={() => setShowTranslationModal(false)}
-                onSave={() => fetchBooks()}
+                onSave={() => { fetchBooks(); fetchTranslationStats(); }}
             />
         </div>
     )

--- a/server/src/common/services/translation.service.ts
+++ b/server/src/common/services/translation.service.ts
@@ -1,0 +1,362 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+interface TranslationFields {
+    name?: string;
+    description?: string;
+    category?: string;
+}
+
+// Simple in-memory cache with TTL
+class TranslationCache {
+    private cache = new Map<string, { value: string; expiresAt: number }>();
+    private readonly defaultTTL = 24 * 60 * 60 * 1000; // 24 hours
+
+    get(key: string): string | null {
+        const entry = this.cache.get(key);
+        if (!entry) return null;
+        if (Date.now() > entry.expiresAt) {
+            this.cache.delete(key);
+            return null;
+        }
+        return entry.value;
+    }
+
+    set(key: string, value: string, ttlMs?: number): void {
+        this.cache.set(key, {
+            value,
+            expiresAt: Date.now() + (ttlMs || this.defaultTTL),
+        });
+    }
+
+    has(key: string): boolean {
+        return this.get(key) !== null;
+    }
+}
+
+@Injectable()
+export class TranslationService {
+    private readonly logger = new Logger(TranslationService.name);
+    private readonly provider: string;
+    private readonly apiKey: string;
+    private readonly apiUrl: string;
+    private readonly cache = new TranslationCache();
+    private lastCallTime = 0;
+    private readonly minIntervalMs = 500; // Rate limit: max 10 calls/sec
+
+    constructor(private configService: ConfigService) {
+        this.provider = this.configService.get<string>('TRANSLATION_PROVIDER', 'libre');
+        this.apiKey = this.configService.get<string>('TRANSLATION_API_KEY', '');
+        this.apiUrl = this.configService.get<string>(
+            'TRANSLATION_API_URL',
+            'http://localhost:5000',
+        );
+
+        this.logger.log(`TranslationService initialized with provider: ${this.provider}`);
+    }
+
+    /**
+     * Translate a single text string between languages
+     */
+    async translateText(text: string, from: string, to: string): Promise<string> {
+        if (!text || text.trim().length === 0) return text;
+        if (from === to) return text;
+
+        // Check cache
+        const cacheKey = `${from}:${to}:${text}`;
+        const cached = this.cache.get(cacheKey);
+        if (cached) {
+            this.logger.debug(`Cache hit for translation: "${text.substring(0, 30)}..."`);
+            return cached;
+        }
+
+        // Rate limiting
+        await this.enforceRateLimit();
+
+        let translated: string;
+
+        switch (this.provider) {
+            case 'google':
+                translated = await this.translateWithGoogle(text, from, to);
+                break;
+            case 'gemini':
+                translated = await this.translateWithGemini(text, from, to);
+                break;
+            case 'deepl':
+                translated = await this.translateWithDeepL(text, from, to);
+                break;
+            case 'libre':
+            default:
+                translated = await this.translateWithLibre(text, from, to);
+                break;
+        }
+
+        // Store in cache
+        this.cache.set(cacheKey, translated);
+
+        return translated;
+    }
+
+    /**
+     * Translate product fields (name, description, category)
+     */
+    async translateProduct(
+        product: TranslationFields,
+        from: string,
+        to: string,
+    ): Promise<TranslationFields> {
+        const results: TranslationFields = {};
+
+        if (product.name) {
+            results.name = await this.translateText(product.name, from, to);
+        }
+
+        if (product.description) {
+            // Translate description in chunks if too long (API limit ~5000 chars)
+            results.description = await this.translateLongText(product.description, from, to);
+        }
+
+        if (product.category) {
+            results.category = await this.translateText(product.category, from, to);
+        }
+
+        return results;
+    }
+
+    /**
+     * Translate long text by splitting into chunks
+     */
+    private async translateLongText(text: string, from: string, to: string): Promise<string> {
+        const maxChunkSize = 4500; // Safe limit under 5000
+
+        if (text.length <= maxChunkSize) {
+            return this.translateText(text, from, to);
+        }
+
+        // Split by paragraphs first, then by sentences if needed
+        const chunks = this.splitTextIntoChunks(text, maxChunkSize);
+        const translatedChunks: string[] = [];
+
+        for (const chunk of chunks) {
+            const translated = await this.translateText(chunk, from, to);
+            translatedChunks.push(translated);
+        }
+
+        return translatedChunks.join('\n');
+    }
+
+    /**
+     * Split text into chunks respecting sentence boundaries
+     */
+    private splitTextIntoChunks(text: string, maxLen: number): string[] {
+        const chunks: string[] = [];
+        let remaining = text;
+
+        while (remaining.length > 0) {
+            if (remaining.length <= maxLen) {
+                chunks.push(remaining);
+                break;
+            }
+
+            // Try to split at a sentence boundary
+            let splitIndex = remaining.lastIndexOf('. ', maxLen);
+            if (splitIndex < maxLen * 0.3) {
+                // No good sentence boundary, split at space
+                splitIndex = remaining.lastIndexOf(' ', maxLen);
+            }
+            if (splitIndex < maxLen * 0.3) {
+                // No space found, force split
+                splitIndex = maxLen;
+            } else {
+                splitIndex += 1; // Include the period/space
+            }
+
+            chunks.push(remaining.substring(0, splitIndex));
+            remaining = remaining.substring(splitIndex).trimStart();
+        }
+
+        return chunks;
+    }
+
+    /**
+     * Rate limiting: enforce minimum interval between API calls
+     */
+    private async enforceRateLimit(): Promise<void> {
+        const now = Date.now();
+        const elapsed = now - this.lastCallTime;
+        if (elapsed < this.minIntervalMs) {
+            await new Promise(resolve => setTimeout(resolve, this.minIntervalMs - elapsed));
+        }
+        this.lastCallTime = Date.now();
+    }
+
+    // === PROVIDER IMPLEMENTATIONS ===
+
+    /**
+     * LibreTranslate (self-hosted, free)
+     */
+    private async translateWithLibre(text: string, from: string, to: string): Promise<string> {
+        try {
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+            const response = await fetch(`${this.apiUrl}/translate`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    q: text,
+                    source: from,
+                    target: to,
+                    format: 'text',
+                }),
+                signal: controller.signal,
+            });
+
+            clearTimeout(timeoutId);
+
+            if (!response.ok) {
+                throw new Error(`LibreTranslate returned ${response.status}`);
+            }
+
+            const data = await response.json();
+            return data.translatedText || text;
+        } catch (error: any) {
+            this.logger.warn(`LibreTranslate failed, returning original text: ${error.message}`);
+            return text; // Fallback to original
+        }
+    }
+
+    /**
+     * Google Cloud Translation API (v2)
+     */
+    private async translateWithGoogle(text: string, from: string, to: string): Promise<string> {
+        try {
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+            const url = `https://translation.googleapis.com/language/translate/v2?key=${this.apiKey}`;
+
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    q: text,
+                    source: from,
+                    target: to,
+                    format: 'text',
+                }),
+                signal: controller.signal,
+            });
+
+            clearTimeout(timeoutId);
+
+            if (!response.ok) {
+                throw new Error(`Google Translate returned ${response.status}`);
+            }
+
+            const data = await response.json();
+            return data.data.translations[0].translatedText || text;
+        } catch (error: any) {
+            this.logger.warn(`Google Translate failed, returning original text: ${error.message}`);
+            return text;
+        }
+    }
+
+    /**
+     * Google Gemini API (via AI Studio) — free tier
+     */
+    private async translateWithGemini(text: string, from: string, to: string): Promise<string> {
+        try {
+            const langNames: Record<string, string> = {
+                en: 'English',
+                es: 'Spanish',
+            };
+
+            const sourceLang = langNames[from] || from;
+            const targetLang = langNames[to] || to;
+
+            const prompt = `Translate the following text from ${sourceLang} to ${targetLang}. Return ONLY the translated text, nothing else. Do not add quotes, explanations, or any extra text.\n\nText to translate:\n${text}`;
+
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 15000);
+
+            const response = await fetch(
+                `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${this.apiKey}`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        contents: [{ parts: [{ text: prompt }] }],
+                        generationConfig: {
+                            temperature: 0.1,
+                            maxOutputTokens: 2048,
+                        },
+                    }),
+                    signal: controller.signal,
+                },
+            );
+
+            clearTimeout(timeoutId);
+
+            if (!response.ok) {
+                const errorBody = await response.text();
+                throw new Error(`Gemini API returned ${response.status}: ${errorBody}`);
+            }
+
+            const data = await response.json();
+            const translated = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+
+            if (!translated) {
+                throw new Error('Gemini returned empty translation');
+            }
+
+            return translated;
+        } catch (error: any) {
+            this.logger.warn(`Gemini translation failed, returning original text: ${error.message}`);
+            return text;
+        }
+    }
+
+    /**
+     * DeepL API
+     */
+    private async translateWithDeepL(text: string, from: string, to: string): Promise<string> {
+        try {
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+            // DeepL uses 'EN-US' or 'EN-GB' for English
+            const deeplFrom = from === 'en' ? 'EN' : from.toUpperCase();
+            const deeplTo = to === 'en' ? 'EN-US' : to.toUpperCase();
+
+            const baseUrl = this.apiKey.endsWith(':fx')
+                ? 'https://api-free.deepl.com/v2/translate'
+                : 'https://api.deepl.com/v2/translate';
+
+            const params = new URLSearchParams();
+            params.append('auth_key', this.apiKey);
+            params.append('text', text);
+            params.append('source_lang', deeplFrom);
+            params.append('target_lang', deeplTo);
+
+            const response = await fetch(baseUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: params.toString(),
+                signal: controller.signal,
+            });
+
+            clearTimeout(timeoutId);
+
+            if (!response.ok) {
+                throw new Error(`DeepL returned ${response.status}`);
+            }
+
+            const data = await response.json();
+            return data.translations[0].text || text;
+        } catch (error: any) {
+            this.logger.warn(`DeepL failed, returning original text: ${error.message}`);
+            return text;
+        }
+    }
+}

--- a/server/src/products/dto/add-product.dto.ts
+++ b/server/src/products/dto/add-product.dto.ts
@@ -113,4 +113,19 @@ export class AddProductDto {
     })
     @IsBoolean()
     inStock?: boolean = true;
+
+    @ApiProperty({
+        example: true,
+        description: 'Auto-translate product to the other language on creation',
+        required: false,
+        default: true,
+    })
+    @IsOptional()
+    @Transform(({ value }) => {
+        if (value === 'true' || value === true) return true;
+        if (value === 'false' || value === false) return false;
+        return true;
+    })
+    @IsBoolean()
+    autoTranslate?: boolean = true;
 }

--- a/server/src/products/dto/translate-batch.dto.ts
+++ b/server/src/products/dto/translate-batch.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsIn, IsNotEmpty, IsString, ArrayMinSize } from 'class-validator';
+
+export class TranslateBatchDto {
+    @ApiProperty({
+        description: 'Array of product IDs to translate',
+        example: ['abc123', 'def456'],
+    })
+    @IsNotEmpty()
+    @IsArray()
+    @ArrayMinSize(1)
+    @IsString({ each: true })
+    productIds: string[];
+
+    @ApiProperty({
+        description: 'Target language code',
+        example: 'es',
+        enum: ['es', 'en'],
+    })
+    @IsNotEmpty()
+    @IsString()
+    @IsIn(['es', 'en'])
+    toLanguage: string;
+}

--- a/server/src/products/dto/translate-product.dto.ts
+++ b/server/src/products/dto/translate-product.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsIn } from 'class-validator';
+
+export class TranslateProductDto {
+    @ApiProperty({
+        description: 'Target language code',
+        example: 'es',
+        enum: ['es', 'en'],
+    })
+    @IsNotEmpty()
+    @IsString()
+    @IsIn(['es', 'en'])
+    toLanguage: string;
+}

--- a/server/src/products/product.controller.ts
+++ b/server/src/products/product.controller.ts
@@ -10,6 +10,7 @@ import { SingleProductDto } from './dto/single-product.dto';
 import { ChangeStockDto } from './dto/change-stock.dto';
 import { SearchProductDto } from './dto/search-product.dto';
 import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { TranslateBatchDto } from './dto/translate-batch.dto';
 
 @ApiTags('Product')
 @Controller('product')
@@ -814,6 +815,141 @@ export class ProductController {
                 success: true,
                 productId,
                 translations: result.translations,
+            });
+        } catch (error: any) {
+            return res
+                .status(error.status || HttpStatus.INTERNAL_SERVER_ERROR)
+                .json({
+                    success: false,
+                    message: error.message,
+                });
+        }
+    }
+
+    @Post('translate/:productId/:toLanguage')
+    @UseGuards(AdminAuthGuard)
+    @ApiCookieAuth('adminToken')
+    @ApiOperation({ summary: 'Auto-translate a product to the target language (Admin only)' })
+    @ApiParam({ name: 'productId', description: 'Product ID' })
+    @ApiParam({ name: 'toLanguage', description: 'Target language code', example: 'es', enum: ['es', 'en'] })
+    @ApiResponse({ status: 200, description: 'Product translated successfully' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    @ApiResponse({ status: 404, description: 'Product not found' })
+    async translateProduct(
+        @Param('productId') productId: string,
+        @Param('toLanguage') toLanguage: string,
+        @Res() res: Response,
+    ) {
+        try {
+            if (!['es', 'en'].includes(toLanguage)) {
+                return res.status(HttpStatus.BAD_REQUEST).json({
+                    success: false,
+                    message: 'Invalid language. Supported: es, en',
+                });
+            }
+
+            const result = await this.productService.translateProductAuto(productId, toLanguage);
+
+            return res.status(HttpStatus.OK).json({
+                success: true,
+                ...result,
+            });
+        } catch (error: any) {
+            return res
+                .status(error.status || HttpStatus.INTERNAL_SERVER_ERROR)
+                .json({
+                    success: false,
+                    message: error.message,
+                });
+        }
+    }
+
+    @Post('translate-batch')
+    @UseGuards(AdminAuthGuard)
+    @ApiCookieAuth('adminToken')
+    @ApiOperation({ summary: 'Auto-translate multiple products in batch (Admin only)' })
+    @ApiBody({ type: TranslateBatchDto })
+    @ApiResponse({ status: 200, description: 'Batch translation completed' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    async translateBatch(
+        @Body() translateBatchDto: TranslateBatchDto,
+        @Res() res: Response,
+    ) {
+        try {
+            if (!['es', 'en'].includes(translateBatchDto.toLanguage)) {
+                return res.status(HttpStatus.BAD_REQUEST).json({
+                    success: false,
+                    message: 'Invalid language. Supported: es, en',
+                });
+            }
+
+            const result = await this.productService.batchTranslateAuto(
+                translateBatchDto.productIds,
+                translateBatchDto.toLanguage,
+            );
+
+            return res.status(HttpStatus.OK).json({
+                success: true,
+                ...result,
+            });
+        } catch (error: any) {
+            return res
+                .status(error.status || HttpStatus.INTERNAL_SERVER_ERROR)
+                .json({
+                    success: false,
+                    message: error.message,
+                });
+        }
+    }
+
+    @Get('translation-stats')
+    @UseGuards(AdminAuthGuard)
+    @ApiCookieAuth('adminToken')
+    @ApiOperation({ summary: 'Get translation coverage stats (Admin only)' })
+    @ApiResponse({ status: 200, description: 'Translation stats retrieved' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    async getTranslationStats(@Res() res: Response) {
+        try {
+            const stats = await this.productService.getTranslationStats();
+
+            return res.status(HttpStatus.OK).json({
+                success: true,
+                stats,
+            });
+        } catch (error: any) {
+            return res
+                .status(error.status || HttpStatus.INTERNAL_SERVER_ERROR)
+                .json({
+                    success: false,
+                    message: error.message,
+                });
+        }
+    }
+
+    @Post('translate-all/:toLanguage')
+    @UseGuards(AdminAuthGuard)
+    @ApiCookieAuth('adminToken')
+    @ApiOperation({ summary: 'Auto-translate ALL products to the target language (Admin only)' })
+    @ApiParam({ name: 'toLanguage', description: 'Target language code', example: 'es', enum: ['es', 'en'] })
+    @ApiResponse({ status: 200, description: 'All products translated' })
+    @ApiResponse({ status: 401, description: 'Unauthorized' })
+    async translateAll(
+        @Param('toLanguage') toLanguage: string,
+        @Res() res: Response,
+    ) {
+        try {
+            if (!['es', 'en'].includes(toLanguage)) {
+                return res.status(HttpStatus.BAD_REQUEST).json({
+                    success: false,
+                    message: 'Invalid language. Supported: es, en',
+                });
+            }
+
+            const result = await this.productService.translateAllProducts(toLanguage);
+
+            return res.status(HttpStatus.OK).json({
+                success: true,
+                ...result,
             });
         } catch (error: any) {
             return res

--- a/server/src/products/product.module.ts
+++ b/server/src/products/product.module.ts
@@ -3,13 +3,14 @@ import { ProductController } from './product.controller';
 import { ProductService } from './product.service';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Product, ProductSchema } from './schemas/product.schema';
+import { TranslationService } from 'src/common/services/translation.service';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Product.name, schema: ProductSchema }]),
   ],
   controllers: [ProductController],
-  providers: [ProductService],
+  providers: [ProductService, TranslationService],
   exports: [ProductService],
 })
-export class ProductModule {}
+export class ProductModule { }

--- a/server/src/products/product.service.ts
+++ b/server/src/products/product.service.ts
@@ -10,6 +10,7 @@ import { generateISBN, estimatePageCount, assignDefaultAuthor, assignDefaultPubl
 import { PaginatedResult, PaginationDto } from 'src/common/dto/pagination.dto';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { Cache } from 'cache-manager';
+import { TranslationService } from 'src/common/services/translation.service';
 
 @Injectable()
 export class ProductService {
@@ -17,6 +18,7 @@ export class ProductService {
         @InjectModel(Product.name) private productModel: Model<ProductDocument>,
         private configService: ConfigService,
         @Inject(CACHE_MANAGER) private cacheManager: Cache,
+        private translationService: TranslationService,
     ) {
         // Configure cloudinary
         cloudinary.config({
@@ -71,6 +73,14 @@ export class ProductService {
                 publisher: productData.publisher || assignDefaultPublisher(productData.category),
                 publicationYear: productData.publicationYear || generatePublicationYear(),
             });
+
+            // Auto-translate if requested (fire-and-forget, don't block response)
+            if (productData.autoTranslate !== false) {
+                const targetLang = 'es'; // Default: translate to Spanish
+                this.translateProductAuto(newProduct._id.toString(), targetLang).catch((err) => {
+                    console.error(`[ProductService] Auto-translate failed for ${newProduct._id}:`, err.message);
+                });
+            }
 
             return { message: 'Product added' };
         } catch (error: any) {
@@ -547,6 +557,14 @@ export class ProductService {
     async listProductsWithTranslation(lang: string = 'en', pagination: PaginationDto = {}): Promise<PaginatedResult<Product>> {
         try {
             const { page = 1, limit = 20 } = pagination;
+            const cacheKey = `products:list:${lang}:${page}:${limit}`;
+
+            // Attempt cache hit
+            const cached = await this.cacheManager.get<PaginatedResult<Product>>(cacheKey);
+            if (cached) {
+                return cached;
+            }
+
             const skip = (page - 1) * limit;
 
             const [rawProducts, total] = await Promise.all([
@@ -558,7 +576,7 @@ export class ProductService {
                 ? rawProducts
                 : rawProducts.map((product) => this.applyTranslation(product, lang));
 
-            return {
+            const result: PaginatedResult<Product> = {
                 data,
                 pagination: {
                     page,
@@ -567,6 +585,11 @@ export class ProductService {
                     totalPages: Math.ceil(total / limit),
                 },
             };
+
+            // Cache for 2 minutes
+            await this.cacheManager.set(cacheKey, result, 120);
+
+            return result;
         } catch (error: any) {
             throw new InternalServerErrorException(error.message);
         }
@@ -618,8 +641,10 @@ export class ProductService {
 
             if (!updatedProduct) throw new NotFoundException('Product not found after update');
 
-            // Invalidar caché del producto
+            // Invalidar caché del producto y de listados
             await this.cacheManager.del(`product:${productId}`);
+            // Invalidate all product list caches (pattern-based)
+            await this.invalidateProductListCache();
 
             return {
                 message: `Translation for ${lang} updated successfully`,
@@ -807,5 +832,154 @@ export class ProductService {
         }
 
         return result.concat(left.slice(l)).concat(right.slice(r));
+    }
+
+    /**
+     * Traduce un producto automáticamente al idioma destino usando el TranslationService
+     */
+    async translateProductAuto(
+        productId: string,
+        toLanguage: string,
+    ): Promise<{ message: string; translation: { name: string; description: string; category: string } }> {
+        try {
+            const product = await this.productModel.findById(productId);
+            if (!product) throw new NotFoundException('Product not found');
+
+            // Determine source language: if translations[toLanguage] exists, the original might be the other one
+            const fromLanguage = toLanguage === 'es' ? 'en' : 'es';
+
+            const translatedFields = await this.translationService.translateProduct(
+                { name: product.name, description: product.description, category: product.category },
+                fromLanguage,
+                toLanguage,
+            );
+
+            const safeTranslatedFields = {
+                name: translatedFields.name ?? product.name,
+                description: translatedFields.description ?? product.description,
+                category: translatedFields.category ?? product.category,
+            };
+
+            // Merge with existing translations
+            const translations = product.translations || {};
+            translations[toLanguage] = {
+                name: safeTranslatedFields.name,
+                description: safeTranslatedFields.description,
+                category: safeTranslatedFields.category,
+                translatedAt: new Date(),
+                translatedBy: 'automatic',
+            };
+
+            await this.productModel.findByIdAndUpdate(
+                productId,
+                { translations },
+                { new: true },
+            );
+
+            // Invalidate cache
+            await this.cacheManager.del(`product:${productId}`);
+            await this.invalidateProductListCache();
+
+            return {
+                message: `Product translated to ${toLanguage} successfully`,
+                translation: safeTranslatedFields,
+            };
+        } catch (error: any) {
+            if (error instanceof NotFoundException) throw error;
+            throw new InternalServerErrorException(`Translation failed: ${error.message}`);
+        }
+    }
+
+    /**
+     * Traduce múltiples productos en lote al idioma destino
+     */
+    async batchTranslateAuto(
+        productIds: string[],
+        toLanguage: string,
+    ): Promise<{ message: string; translated: number; failed: number; errors: string[] }> {
+        let translated = 0;
+        let failed = 0;
+        const errors: string[] = [];
+
+        for (const productId of productIds) {
+            try {
+                await this.translateProductAuto(productId, toLanguage);
+                translated++;
+            } catch (error: any) {
+                failed++;
+                errors.push(`${productId}: ${error.message}`);
+            }
+        }
+
+        return {
+            message: `Batch translation completed: ${translated} translated, ${failed} failed`,
+            translated,
+            failed,
+            errors,
+        };
+    }
+
+    /**
+     * Obtiene estadísticas de cobertura de traducciones
+     */
+    async getTranslationStats(): Promise<{
+        total: number;
+        translatedEs: number;
+        translatedEn: number;
+        pendingEs: number;
+        pendingEn: number;
+    }> {
+        try {
+            const total = await this.productModel.countDocuments();
+
+            const translatedEs = await this.productModel.countDocuments({
+                'translations.es': { $exists: true, $ne: null },
+            });
+
+            const translatedEn = await this.productModel.countDocuments({
+                'translations.en': { $exists: true, $ne: null },
+            });
+
+            return {
+                total,
+                translatedEs,
+                translatedEn,
+                pendingEs: total - translatedEs,
+                pendingEn: total - translatedEn,
+            };
+        } catch (error: any) {
+            throw new InternalServerErrorException(error.message);
+        }
+    }
+
+    /**
+     * Invalida todas las cachés de listado de productos
+     */
+    private async invalidateProductListCache(): Promise<void> {
+        // Since cache-manager doesn't support pattern deletion out of the box,
+        // we delete known keys. For a production system, consider using Redis keys().
+        const langs = ['en', 'es'];
+        for (const lang of langs) {
+            for (let page = 1; page <= 10; page++) {
+                for (const limit of [20, 50, 100]) {
+                    await this.cacheManager.del(`products:list:${lang}:${page}:${limit}`);
+                }
+            }
+        }
+        // Also invalidate the default (no lang) list cache
+        for (let page = 1; page <= 10; page++) {
+            for (const limit of [20, 50, 100]) {
+                await this.cacheManager.del(`products:list:${page}:${limit}`);
+            }
+        }
+    }
+
+    /**
+     * Traduce TODOS los productos al idioma destino
+     */
+    async translateAllProducts(toLanguage: string): Promise<{ message: string; translated: number; failed: number; errors: string[] }> {
+        const allProducts = await this.productModel.find().lean();
+        const productIds = allProducts.map(p => p._id.toString());
+        return this.batchTranslateAuto(productIds, toLanguage);
     }
 }

--- a/server/src/products/product.service.ts
+++ b/server/src/products/product.service.ts
@@ -845,8 +845,13 @@ export class ProductService {
             const product = await this.productModel.findById(productId);
             if (!product) throw new NotFoundException('Product not found');
 
-            // Determine source language: if translations[toLanguage] exists, the original might be the other one
-            const fromLanguage = toLanguage === 'es' ? 'en' : 'es';
+            // Base product fields are stored in English; only translating away from the base is meaningful.
+            const fromLanguage = 'en';
+            if (toLanguage === fromLanguage) {
+                throw new InternalServerErrorException(
+                    `Cannot translate to base language "${toLanguage}"`,
+                );
+            }
 
             const translatedFields = await this.translationService.translateProduct(
                 { name: product.name, description: product.description, category: product.category },

--- a/server/src/products/schemas/product.schema.ts
+++ b/server/src/products/schemas/product.schema.ts
@@ -13,6 +13,12 @@ export class ProductTranslation {
 
     @Prop({ type: String })
     category?: string;
+
+    @Prop({ type: Date })
+    translatedAt?: Date;
+
+    @Prop({ type: String })
+    translatedBy?: string; // 'automatic' | 'manual' | email del admin
 }
 
 @Schema({ timestamps: true })


### PR DESCRIPTION
- Add TranslationService with multi-provider support (Google, DeepL, LibreTranslate)
- Add auto-translate on product creation
- Add batch translate and translate-all endpoints (Admin)
- Add translation stats endpoint
- Update ProductSchema with translatedAt and translatedBy fields
- Add cache to listProductsWithTranslation endpoint
- Update TranslationModal with auto-translate button and ES/EN tabs
- Add translation progress badges in ProductList
- Add auto-translate checkbox in AddProduct
- Add productTranslations i18n keys for EN and ES

Closes: #221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spanish and English translation tabs for product editing.
  * Added automatic translation on product save, with an option to disable it.
  * Added individual, batch, and bulk translation actions.
  * Added translation progress statistics and Spanish/English availability indicators.
  * Added translation metadata, including last updated time and translator.
  * Added localized translation workflow labels in English and Spanish.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->